### PR TITLE
Move LED Display switch to configuration

### DIFF
--- a/custom_components/midea_ac/switch.py
+++ b/custom_components/midea_ac/switch.py
@@ -74,6 +74,10 @@ class MideaDisplaySwitch(SwitchEntity, RestoreEntity):
         }
 
     @property
+    def entity_category(self) -> dict:
+        return EntityCategory.CONFIG
+
+    @property
     def name(self) -> str:
         return f"{DOMAIN}_display_{self._device.id}"
 


### PR DESCRIPTION
this is not fixing an issue it's just to organize HA device UI since LED entity sometimes goes above the AC control in controls category this PR moves switch to configuration category instead of Controls.

![image](https://github.com/mill1000/midea-ac-py/assets/46300268/63abc88c-0120-4009-a875-f6bbfaac143c)