### PR TITLE
Update config flow to not allow configuration of unsupported devices

### DIFF
--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -9,9 +9,9 @@ from homeassistant.config_entries import ConfigEntry, ConfigFlow, OptionsFlow
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
+from msmart.const import DeviceType
 from msmart.device import AirConditioner as AC
 from msmart.discover import Discover
-from msmart.const import DeviceType
 
 # Local constants
 from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_BEEP,

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -11,6 +11,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from msmart.device import AirConditioner as AC
 from msmart.discover import Discover
+from msmart.const import DeviceType
 
 # Local constants
 from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_BEEP,
@@ -51,7 +52,9 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
             device = await Discover.discover_single(host, auto_connect=False, timeout=2)
 
             if device is None:
-                errors["base"] = "no_devices_found"
+                errors["base"] = "device_not_found"
+            elif device.type != DeviceType.AIR_CONDITIONER:
+                errors["base"] = "unsupported_device"
             else:
                 # Check if device has already been configured
                 await self.async_set_unique_id(device.id)
@@ -108,7 +111,8 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 f"{device.name} - {device.id} ({device.ip})"
             )
             for device in self._discovered_devices
-            if device.id not in configured_devices
+            if (device.id not in configured_devices and
+                device.type == DeviceType.AIR_CONDITIONER)
         }
 
         # Check if there is at least one device

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -31,11 +31,12 @@
     },
     "abort": {
       "already_configured": "The device has already been configured.",
-      "no_devices_found": "No device(s) found on the network."
+      "no_devices_found": "No supported devices found on the network."
     },
     "error": {
       "cannot_connect": "A connection could not be made with these settings.",
-      "no_devices_found": "No device(s) found on the network."
+      "device_not_found": "Device not found on the network.",
+      "unsupported_device": "Device is not supported."
     }
   },
   "options": {


### PR DESCRIPTION
Originally noticed in #22, we were displaying all found devices on the network even if they weren't supported.

Close #24 
