### PR TITLE
Abort config flow on failed auto configuration

### DIFF
--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -67,7 +67,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self._create_entry_from_device(device)
                 else:
                     # Indicate a connection could not be made
-                    errors["base"] = "cannot_connect"
+                    return self.async_abort(reason="cannot_connect")
 
         data_schema = vol.Schema({
             vol.Optional(CONF_HOST, default=""): str
@@ -97,7 +97,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     return await self._create_entry_from_device(device)
                 else:
                     # Indicate a connection could not be made
-                    errors["base"] = "cannot_connect"
+                    return self.async_abort(reason="cannot_connect")
 
         # Create a set of already configured devices by ID
         configured_devices = {

--- a/custom_components/midea_ac/strings.json
+++ b/custom_components/midea_ac/strings.json
@@ -31,6 +31,7 @@
     },
     "abort": {
       "already_configured": "The device has already been configured.",
+      "cannot_connect": "A connection could not be made.",
       "no_devices_found": "No supported devices found on the network."
     },
     "error": {

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -31,6 +31,7 @@
     },
     "abort": {
       "already_configured": "The device has already been configured.",
+      "cannot_connect": "A connection could not be made.",
       "no_devices_found": "No supported devices found on the network."
     },
     "error": {


### PR DESCRIPTION
Abort the config flow when auto config fails due to a connection failure.

Close #35 