### PR TITLE
Intelligently populate fan speed options and add support for custom fan speeds

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -69,6 +69,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass.config_entries.async_forward_entry_setup(config_entry, "binary_sensor"))
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(config_entry, "switch"))
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(config_entry, "number"))
 
     # Reload entry when its updated
     config_entry.async_on_unload(

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -270,9 +270,6 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
         """Return the current fan speed mode."""
         fan_speed = self._device.fan_speed
 
-        _LOGGER.info("Got fan mode %s", fan_speed)
-        _LOGGER.info("Got fan mode type %s", type(fan_speed))
-
         if isinstance(fan_speed, AC.FanSpeed):
             return fan_speed.name.capitalize()
         elif isinstance(fan_speed, int):
@@ -283,9 +280,6 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
 
     async def async_set_fan_mode(self, fan_mode) -> None:
         """Set the fan mode."""
-
-        _LOGGER.info("Set fan mode %s", fan_mode)
-        _LOGGER.info("Set fan mode type %s", type(fan_mode))
 
         # Don't override custom fan speeds
         if fan_mode == _FAN_CUSTOM:

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -121,8 +121,16 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
                 _LOGGER.info(f"Adding additional mode '{mode}'.")
                 self._hvac_modes.append(mode)
 
-        # Convert Midea fan speeds to strings
-        self._fan_modes = [m.name.capitalize() for m in AC.FanSpeed.list()]
+        # Fetch supported fan speeds
+        supported_fan_speeds = getattr(
+            self._device, "supported_fan_speeds", AC.FanSpeed.list())
+
+        # Convert Midea swing modes to strings
+        self._fan_modes = [m.name.capitalize()
+                           for m in supported_fan_speeds]
+
+        # if getattr(self._device, "supports_custom_fan_speed", False):
+        #     supported_fan_speeds.append("CUSTOM")
 
         # Fetch supported swing modes
         supported_swing_modes = getattr(
@@ -255,7 +263,13 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
     @property
     def fan_mode(self) -> str:
         """Return the current fan speed mode."""
-        return self._device.fan_speed.name.capitalize()
+        fan_speed = self._device.fan_speed
+        _LOGGER.info("Got fan mode %s", fan_speed)
+        if isinstance(fan_speed, AC.FanSpeed):
+            fan_speed = fan_speed.name
+        else:
+            fan_speed = "Custom"
+        return fan_speed.capitalize()
 
     async def async_set_fan_mode(self, fan_mode) -> None:
         """Set the fan mode."""

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -260,7 +260,7 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
 
         # Add "Custom" to the list if a device supports custom fan speeds, and is using a custom speed
         if (getattr(self._device, "supports_custom_fan_speed", False)
-                and isinstance(self._device.fan_speed, int)):
+                and not isinstance(self._device.fan_speed, AC.FanSpeed)):
             return [_FAN_CUSTOM] + self._fan_modes
 
         return self._fan_modes

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -6,6 +6,7 @@ import logging
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
+from homeassistant.helpers.debounce import Debouncer
 from msmart.device import AirConditioner as AC
 
 from .const import DOMAIN
@@ -22,6 +23,12 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER,
             name=DOMAIN,
             update_interval=datetime.timedelta(seconds=15),
+            request_refresh_debouncer = Debouncer(
+                hass,
+                _LOGGER,
+                cooldown=1,
+                immediate=True,
+            )
         )
 
         self._device = device

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -4,9 +4,9 @@ import datetime
 import logging
 
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
-from homeassistant.helpers.debounce import Debouncer
 from msmart.device import AirConditioner as AC
 
 from .const import DOMAIN
@@ -23,7 +23,7 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
             _LOGGER,
             name=DOMAIN,
             update_interval=datetime.timedelta(seconds=15),
-            request_refresh_debouncer = Debouncer(
+            request_refresh_debouncer=Debouncer(
                 hass,
                 _LOGGER,
                 cooldown=1,

--- a/custom_components/midea_ac/number.py
+++ b/custom_components/midea_ac/number.py
@@ -10,7 +10,6 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from msmart.device import AirConditioner as AC
 
-# Local constants
 from .const import DOMAIN
 from .coordinator import MideaCoordinatorEntity, MideaDeviceUpdateCoordinator
 

--- a/custom_components/midea_ac/number.py
+++ b/custom_components/midea_ac/number.py
@@ -1,0 +1,93 @@
+"""Platform for switch integration."""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import PERCENTAGE
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from msmart.device import AirConditioner as AC
+
+# Local constants
+from .const import DOMAIN
+from .coordinator import MideaCoordinatorEntity, MideaDeviceUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    add_entities: AddEntitiesCallback,
+) -> None:
+    """Setup the number platform for Midea Smart AC."""
+
+    _LOGGER.info("Setting up number platform.")
+
+    # Fetch coordinator from global data
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Create sensor entities from device if supported
+    if getattr(coordinator.device, "supports_custom_fan_speed", False):
+        add_entities([MideaFanSpeedNumber(coordinator)])
+
+
+class MideaFanSpeedNumber(MideaCoordinatorEntity, NumberEntity):
+    """Fan speed number for Midea AC."""
+
+    def __init__(self, coordinator: MideaDeviceUpdateCoordinator) -> None:
+        MideaCoordinatorEntity.__init__(self, coordinator)
+
+    @property
+    def device_info(self) -> dict:
+        """Return info for device registry."""
+        return {
+            "identifiers": {
+                (DOMAIN, self._device.id)
+            },
+        }
+
+    @property
+    def name(self) -> str:
+        """Return the name of this entity."""
+        return f"{DOMAIN}_fan_speed_{self._device.id}"
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID of this entity."""
+        return f"{self._device.id}-fan_speed"
+
+    @property
+    def native_unit_of_measurement(self) -> str:
+        return PERCENTAGE
+
+    @property
+    def native_max_value(self) -> float:
+        return 100
+
+    @property
+    def native_min_value(self) -> float:
+        return 1
+
+    @property
+    def native_value(self) -> float:
+
+        speed = self._device.fan_speed
+
+        # Convert enum to integer
+        if isinstance(speed, AC.FanSpeed):
+            speed = speed.value
+
+        _LOGGER.info("Got value %s.", speed)
+        return speed
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Set a new fan speed value."""
+
+        self._device.fan_speed = value
+        _LOGGER.info("Set value %s.", value)
+
+        # Apply via the coordinator
+        await self.coordinator.apply()

--- a/custom_components/midea_ac/number.py
+++ b/custom_components/midea_ac/number.py
@@ -60,6 +60,11 @@ class MideaFanSpeedNumber(MideaCoordinatorEntity, NumberEntity):
         return f"{self._device.id}-fan_speed"
 
     @property
+    def available(self) -> bool:
+        """Check device availability."""
+        return self._device.online and self._device.power_state
+
+    @property
     def native_unit_of_measurement(self) -> str:
         return PERCENTAGE
 

--- a/custom_components/midea_ac/number.py
+++ b/custom_components/midea_ac/number.py
@@ -84,14 +84,12 @@ class MideaFanSpeedNumber(MideaCoordinatorEntity, NumberEntity):
         if isinstance(speed, AC.FanSpeed):
             speed = speed.value
 
-        _LOGGER.info("Got value %s.", speed)
         return speed
 
     async def async_set_native_value(self, value: float) -> None:
         """Set a new fan speed value."""
 
         self._device.fan_speed = value
-        _LOGGER.info("Set value %s.", value)
 
         # Apply via the coordinator
         await self.coordinator.apply()


### PR DESCRIPTION
Use device capabilities to intelligently populate available fan speeds. On devices that support it, add a custom fan speed control via a number entity.

Also, reduce de-bounce on coordinator to make number and climate response better.

Close #40 
