### PR TITLE
Add a service to control "follow me" feature

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -14,7 +14,8 @@ from homeassistant.components.climate.const import (PRESET_AWAY, PRESET_BOOST,
                                                     SUPPORT_TARGET_TEMPERATURE,
                                                     HVACMode)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_TEMPERATURE, TEMP_CELSIUS, TEMP_FAHRENHEIT
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_ENABLED, TEMP_CELSIUS,
+                                 TEMP_FAHRENHEIT)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform
@@ -48,9 +49,10 @@ _HVAC_MODE_TO_OPERATIONAL_MODE: dict[HVACMode, AC.OperationalMode] = {
     HVACMode.AUTO: AC.OperationalMode.AUTO,
 }
 
+_ATTR_FOLLOW_ME = "follow_me"
 _SERVICE_SET_FOLLOW_ME = "set_follow_me"
 _SERVICE_SET_FOLLOW_ME_SCHEMA = {
-    vol.Required("enable"): cv.bool,
+    vol.Required(CONF_ENABLED): cv.bool,
 }
 
 
@@ -177,11 +179,6 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
         self._max_temperature = getattr(
             self._device, "max_target_temperature", 30)
 
-    async def async_set_follow_me(self, enable) -> None:
-        """Set 'follow me' mode."""
-        self._device.follow_me = enable
-        await self._apply()
-
     async def _apply(self) -> None:
         """Apply changes to the device."""
 
@@ -222,6 +219,11 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
     def should_poll(self) -> bool:
         """Poll the appliance for changes, there is no notification capability in the Midea API"""
         return not self._use_fan_only_workaround
+
+    async def async_set_follow_me(self, enabled) -> None:
+        """Set 'follow me' mode."""
+        self._device.follow_me = enabled
+        await self._apply()
 
     @property
     def supported_features(self) -> int:

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -220,6 +220,18 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
         """Poll the appliance for changes, there is no notification capability in the Midea API"""
         return not self._use_fan_only_workaround
 
+    @property
+    def extra_state_attributes(self) -> dict[str, str]:
+        """Return device specific state attributes."""
+
+        state_attributes = {}
+
+        if hasattr(self._device, "follow_me"):
+            state_attributes[_ATTR_FOLLOW_ME] = getattr(
+                self._device, "follow_me")
+
+        return state_attributes
+
     async def async_set_follow_me(self, enabled) -> None:
         """Set 'follow me' mode."""
         self._device.follow_me = enabled

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -49,12 +49,6 @@ _HVAC_MODE_TO_OPERATIONAL_MODE: dict[HVACMode, AC.OperationalMode] = {
     HVACMode.AUTO: AC.OperationalMode.AUTO,
 }
 
-_ATTR_FOLLOW_ME = "follow_me"
-_SERVICE_SET_FOLLOW_ME = "set_follow_me"
-_SERVICE_SET_FOLLOW_ME_SCHEMA = {
-    vol.Required(CONF_ENABLED): cv.boolean,
-}
-
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -76,8 +70,10 @@ async def async_setup_entry(
     if helpers.property_exists(coordinator.device, "follow_me"):
         platform = entity_platform.async_get_current_platform()
         platform .async_register_entity_service(
-            _SERVICE_SET_FOLLOW_ME,
-            _SERVICE_SET_FOLLOW_ME_SCHEMA,
+            "set_follow_me",
+            {
+                vol.Required(CONF_ENABLED): cv.boolean,
+            },
             "async_set_follow_me",
         )
 
@@ -227,7 +223,7 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
         state_attributes = {}
 
         if hasattr(self._device, "follow_me"):
-            state_attributes[_ATTR_FOLLOW_ME] = getattr(
+            state_attributes["follow_me"] = getattr(
                 self._device, "follow_me")
 
         return state_attributes

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -52,7 +52,7 @@ _HVAC_MODE_TO_OPERATIONAL_MODE: dict[HVACMode, AC.OperationalMode] = {
 _ATTR_FOLLOW_ME = "follow_me"
 _SERVICE_SET_FOLLOW_ME = "set_follow_me"
 _SERVICE_SET_FOLLOW_ME_SCHEMA = {
-    vol.Required(CONF_ENABLED): cv.bool,
+    vol.Required(CONF_ENABLED): cv.boolean,
 }
 
 

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -72,13 +72,14 @@ async def async_setup_entry(
         MideaClimateACDevice(hass, coordinator, config_entry.options)
     ])
 
-    # Add a service to control 'follow me' function.
-    platform = entity_platform.async_get_current_platform()
-    platform .async_register_entity_service(
-        _SERVICE_SET_FOLLOW_ME,
-        _SERVICE_SET_FOLLOW_ME_SCHEMA,
-        "async_set_follow_me",
-    )
+    # Add a service to control 'follow me' function
+    if helpers.property_exists(coordinator.device, "follow_me"):
+        platform = entity_platform.async_get_current_platform()
+        platform .async_register_entity_service(
+            _SERVICE_SET_FOLLOW_ME,
+            _SERVICE_SET_FOLLOW_ME_SCHEMA,
+            "async_set_follow_me",
+        )
 
 
 class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
@@ -223,7 +224,6 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
     @property
     def extra_state_attributes(self) -> dict[str, str]:
         """Return device specific state attributes."""
-
         state_attributes = {}
 
         if hasattr(self._device, "follow_me"):
@@ -232,7 +232,7 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
 
         return state_attributes
 
-    async def async_set_follow_me(self, enabled) -> None:
+    async def async_set_follow_me(self, enabled: bool) -> None:
         """Set 'follow me' mode."""
         self._device.follow_me = enabled
         await self._apply()

--- a/custom_components/midea_ac/services.yaml
+++ b/custom_components/midea_ac/services.yaml
@@ -4,7 +4,7 @@ set_follow_me:
       integration: midea_ac
       domain: climate
   fields:
-    enable:
+    enabled:
       required: true
       selector:
         boolean:

--- a/custom_components/midea_ac/services.yaml
+++ b/custom_components/midea_ac/services.yaml
@@ -1,0 +1,10 @@
+set_follow_me:
+  target:
+    entity:
+      integration: midea_ac
+      domain: climate
+  fields:
+    enable:
+      required: true
+      selector:
+        boolean:

--- a/custom_components/midea_ac/strings.json
+++ b/custom_components/midea_ac/strings.json
@@ -59,5 +59,19 @@
         }
       }
     }
+  },
+  "services": {
+    "set_follow_me": {
+      "name": "Set follow me",
+      "description": "Set the follow me function.",
+      "fields": {
+        "fields": {
+          "enabled": {
+            "name": "Enabled",
+            "description": "Whether follow me should be enabled."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/midea_ac/strings.json
+++ b/custom_components/midea_ac/strings.json
@@ -65,11 +65,9 @@
       "name": "Set follow me",
       "description": "Set the follow me function.",
       "fields": {
-        "fields": {
-          "enabled": {
-            "name": "Enabled",
-            "description": "Whether follow me should be enabled."
-          }
+        "enabled": {
+          "name": "Enabled",
+          "description": "Whether follow me should be enabled."
         }
       }
     }

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -59,5 +59,19 @@
         }
       }
     }
+  },
+  "services": {
+    "set_follow_me": {
+      "name": "Set follow me",
+      "description": "Set the follow me function.",
+      "fields": {
+        "fields": {
+          "enabled": {
+            "name": "Enabled",
+            "description": "Whether follow me should be enabled."
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -65,11 +65,9 @@
       "name": "Set follow me",
       "description": "Set the follow me function.",
       "fields": {
-        "fields": {
-          "enabled": {
-            "name": "Enabled",
-            "description": "Whether follow me should be enabled."
-          }
+        "enabled": {
+          "name": "Enabled",
+          "description": "Whether follow me should be enabled."
         }
       }
     }


### PR DESCRIPTION
* Add a custom service to control the "follow me" feature introduced in https://github.com/mill1000/midea-msmart/pull/91
* Expose the current "follow me" state in an attribute of the climate entity.

The justification for using a service over a switch is to obscure the feature slightly due to the following reasons.
* There is no capability to determine if this function exists. Without a capability we can't decide when to create a "follow me" switch entity intelligently. Otherwise we would hide the feature behind an integration option.
* Usage of this feature isn't straightforward and is very device specific.

Close #49 and related to https://github.com/mill1000/midea-msmart/issues/89