### PR TITLE
Fix async_unload_entry

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -83,7 +83,7 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     """Unload a config entry."""
     # Remove the coordinator from global data
     try:
-        hass.data[DOMAIN].pop(config_entry.data[CONF_ID])
+        hass.data[DOMAIN].pop(config_entry.entry_id)
     except KeyError:
         _LOGGER.warning("Failed remove device from global data.")
 

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -89,8 +89,9 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 
     await hass.config_entries.async_forward_entry_unload(config_entry, "climate")
     await hass.config_entries.async_forward_entry_unload(config_entry, "sensor")
-    await hass.config_entries.async_forward_entry_unload(config_entry, "switch")
     await hass.config_entries.async_forward_entry_unload(config_entry, "binary_sensor")
+    await hass.config_entries.async_forward_entry_unload(config_entry, "switch")
+    await hass.config_entries.async_forward_entry_unload(config_entry, "number")
 
     return True
 


### PR DESCRIPTION
After adding the number component in #45, we forgot to unload the number component.

Additionally we switched the global key for the coorindate from CONF_ID to the entry_id, which caused the unload task to fail to remove the coordinator