### PR TITLE
Replace deprecated usage of TEMP_ constants

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -11,8 +11,8 @@ from homeassistant.components.climate.const import (PRESET_AWAY, PRESET_BOOST,
                                                     ClimateEntityFeature,
                                                     HVACMode)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (ATTR_TEMPERATURE, CONF_ENABLED, TEMP_CELSIUS,
-                                 TEMP_FAHRENHEIT)
+from homeassistant.const import (ATTR_TEMPERATURE, CONF_ENABLED,
+                                 UnitOfTemperature)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import entity_platform
@@ -176,7 +176,7 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
 
         # Display on the AC should use the same unit as homeassistant
         helpers.set_properties(self._device, ["fahrenheit", "fahrenheit_unit"],
-                               self.hass.config.units.temperature_unit == TEMP_FAHRENHEIT)
+                               self.hass.config.units.temperature_unit == UnitOfTemperature.FAHRENHEIT)
 
         # Apply via the coordinator
         await self.coordinator.apply()
@@ -241,7 +241,7 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
     @property
     def temperature_unit(self) -> str:
         """Return the unit of measurement."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @ property
     def min_temp(self) -> float:

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -6,7 +6,7 @@ import logging
 from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import TEMP_CELSIUS
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -87,7 +87,7 @@ class MideaTemperatureSensor(MideaCoordinatorEntity, SensorEntity):
     @property
     def native_unit_of_measurement(self) -> str:
         """Return the native units pf this entity."""
-        return TEMP_CELSIUS
+        return UnitOfTemperature.CELSIUS
 
     @property
     def native_value(self) -> float | None:


### PR DESCRIPTION
Close #77 

UnitOfTemperature was introduced about a year ago, so I'm not concerned about dropping the TEMP_ constants and breaking too many years.