### PR TITLE
Use try-catch to add new TURN_OFF/TURN_ON ClimateEntityFeature flags to maintain compatibility with older version of HA.

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -101,10 +101,15 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
         self._supported_features = (
             ClimateEntityFeature.TARGET_TEMPERATURE |
             ClimateEntityFeature.FAN_MODE |
-            ClimateEntityFeature.PRESET_MODE |
-            ClimateEntityFeature.TURN_OFF |
-            ClimateEntityFeature.TURN_ON
+            ClimateEntityFeature.PRESET_MODE
         )
+
+        # Attempt to add new TURN_OFF/TURN_ON features in HA 2024.2
+        try:
+            self._supported_features |= ClimateEntityFeature.TURN_OFF
+            self._supported_features |= ClimateEntityFeature.TURN_ON
+        except AttributeError:
+            pass
 
         # Setup supported presets
         if options.get(CONF_SHOW_ALL_PRESETS):


### PR DESCRIPTION
Hopefully address some issues reported in #88