### PR TITLE
Raise ConfigEntryNotReady when setup fails

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -38,7 +38,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     if token and key:
         success = await device.authenticate(token, key)
         if not success:
-            raise ConfigEntryAuthFailed(
+            raise ConfigEntryNotReady(
                 "Failed to authenticate with device.")
 
     # Configure the connection lifetime


### PR DESCRIPTION
Raise ConfigEntryNotReady instead of ConfigEntryAuthFailed when authentication failed.

This seems counterintuitive, but AuthFailed tries to start a flow to allow a user to re-auth. In our case, auth failures are more likely a network issue so raising NotReady should cause it to try again later.

Close #93 and hopefully help with #90 