### PR TITLE
Define explicit turn_off/turn_on handlers

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -426,3 +426,15 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
             self._device.sleep_mode = True
 
         await self._apply()
+
+    async def async_turn_off(self) -> None:
+        """Turn the device off."""
+
+        self._device.power_state = False
+        await self._apply()
+
+    async def async_turn_on(self) -> None:
+        """Turn the device on."""
+
+        self._device.power_state = True
+        await self._apply()


### PR DESCRIPTION
The implicit handlers caused the HVAC mode to change to HEAT. Close #97 