### PR TITLE
Handle excetions from device authentication

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from msmart import __version__ as MSMART_VERISON
 from msmart.device import AirConditioner as AC
+from msmart.lan import AuthenticationError
 
 from . import helpers
 from .const import CONF_KEY, CONF_MAX_CONNECTION_LIFETIME, DOMAIN
@@ -36,10 +37,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     token = config_entry.data[CONF_TOKEN]
     key = config_entry.data[CONF_KEY]
     if token and key:
-        success = await device.authenticate(token, key)
-        if not success:
+        try:
+            await device.authenticate(token, key)
+        except AuthenticationError as e:
             raise ConfigEntryNotReady(
-                "Failed to authenticate with device.")
+                "Failed to authenticate with device.") from e
 
     # Configure the connection lifetime
     lifetime = config_entry.options.get(CONF_MAX_CONNECTION_LIFETIME)

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -12,6 +12,7 @@ from homeassistant.data_entry_flow import FlowResult
 from msmart.const import DeviceType
 from msmart.device import AirConditioner as AC
 from msmart.discover import Discover
+from msmart.lan import AuthenticationError
 
 from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_BEEP, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME, CONF_SHOW_ALL_PRESETS,
@@ -176,7 +177,11 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         token = config.get(CONF_TOKEN)
         key = config.get(CONF_KEY)
         if token and key:
-            success = await device.authenticate(token, key)
+            try:
+                await device.authenticate(token, key)
+                success = True
+            except AuthenticationError:
+                success = False
         else:
             await device.refresh()
             success = device.online


### PR DESCRIPTION
In forthcoming msmart-ng releases, the authenticate method will throw exceptions on authentication failure (https://github.com/mill1000/midea-msmart/pull/113) .

Update the config flow and init to handle these exceptions