### PR TITLE
Add support for controlling swing angle on supported devices

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -71,6 +71,8 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         hass.config_entries.async_forward_entry_setup(config_entry, "switch"))
     hass.async_create_task(
         hass.config_entries.async_forward_entry_setup(config_entry, "number"))
+    hass.async_create_task(
+        hass.config_entries.async_forward_entry_setup(config_entry, "select"))
 
     # Reload entry when its updated
     config_entry.async_on_unload(

--- a/custom_components/midea_ac/icons.json
+++ b/custom_components/midea_ac/icons.json
@@ -1,0 +1,9 @@
+{
+  "entity": {
+    "select": {
+      "swing_angle": {
+        "default": "mdi:angle-acute"
+      }
+    }
+  }
+}

--- a/custom_components/midea_ac/select.py
+++ b/custom_components/midea_ac/select.py
@@ -10,7 +10,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from msmart.device import AirConditioner as AC
-from msmart.device.AC.device import IntEnumHelper
+from msmart.utils import MideaIntEnum
 
 from .const import DOMAIN
 from .coordinator import MideaCoordinatorEntity, MideaDeviceUpdateCoordinator
@@ -52,7 +52,7 @@ class MideaEnumSelect(MideaCoordinatorEntity, SelectEntity):
     def __init__(self,
                  coordinator: MideaDeviceUpdateCoordinator,
                  prop: str,
-                 enum_class: IntEnumHelper,
+                 enum_class: MideaIntEnum,
                  translation_key = None) -> None:
         MideaCoordinatorEntity.__init__(self, coordinator)
 

--- a/custom_components/midea_ac/select.py
+++ b/custom_components/midea_ac/select.py
@@ -1,0 +1,106 @@
+"""Platform for select integration."""
+from __future__ import annotations
+
+import logging
+
+from typing import List
+
+from homeassistant.components.select import SelectEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from msmart.device import AirConditioner as AC
+from msmart.device.AC.device import IntEnumHelper
+
+from .const import DOMAIN
+from .coordinator import MideaCoordinatorEntity, MideaDeviceUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    add_entities: AddEntitiesCallback,
+) -> None:
+    """Setup the select platform for Midea Smart AC."""
+
+    _LOGGER.info("Setting up select platform.")
+
+    # Fetch coordinator from global data
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Create entities for supported features
+    entities = []
+    if getattr(coordinator.device, "supports_vertical_swing_angle", False):
+        entities.append(MideaEnumSelect(coordinator,
+                                    "vertical_swing_angle",
+                                    AC.SwingAngle))
+
+    if getattr(coordinator.device, "supports_horizontal_swing_angle", False):
+        entities.append(MideaEnumSelect(coordinator,
+                                    "horizontal_swing_angle",
+                                    AC.SwingAngle))
+    add_entities(entities)
+
+
+class MideaEnumSelect(MideaCoordinatorEntity, SelectEntity):
+    """Enum based select for Midea AC."""
+
+    def __init__(self,
+                 coordinator: MideaDeviceUpdateCoordinator,
+                 prop: str,
+                 enum_class: IntEnumHelper) -> None:
+        MideaCoordinatorEntity.__init__(self, coordinator)
+
+        self._prop = prop
+        self._enum_class = enum_class
+        self._name = prop.replace("_", " ").capitalize()
+
+    @property
+    def device_info(self) -> dict:
+        """Return info for device registry."""
+        return {
+            "identifiers": {
+                (DOMAIN, self._device.id)
+            },
+        }
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicates if entity follows naming conventions."""
+        return True
+
+    @property
+    def name(self) -> str:
+        """Return the name of this entity."""
+        return self._name
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID of this entity."""
+        return f"{self._device.id}-{self._prop}"
+
+    @property
+    def available(self) -> bool:
+        """Check device availability."""
+        return self._device.online and self._device.power_state
+
+    @property
+    def current_option(self) -> str:
+        """Get selected option."""
+        return getattr(self._device, self._prop, self._enum_class.DEFAULT).name.lower()
+
+    @property
+    def options(self) -> List[str]:
+        """Get available options."""
+        return [m.name.lower() for m in self._enum_class.list()]
+
+    async def async_select_option(self, option: str) -> None:
+        """Change the selected option."""
+        
+        setattr(self._device, self._prop, self._enum_class.get_from_name(option.upper()))
+        
+        # Apply via the coordinator
+        await self.coordinator.apply()
+

--- a/custom_components/midea_ac/select.py
+++ b/custom_components/midea_ac/select.py
@@ -35,12 +35,14 @@ async def async_setup_entry(
     if getattr(coordinator.device, "supports_vertical_swing_angle", False):
         entities.append(MideaEnumSelect(coordinator,
                                     "vertical_swing_angle",
-                                    AC.SwingAngle))
+                                    AC.SwingAngle,
+                                    "swing_angle"))
 
     if getattr(coordinator.device, "supports_horizontal_swing_angle", False):
         entities.append(MideaEnumSelect(coordinator,
                                     "horizontal_swing_angle",
-                                    AC.SwingAngle))
+                                    AC.SwingAngle,
+                                    "swing_angle"))
     add_entities(entities)
 
 
@@ -50,11 +52,13 @@ class MideaEnumSelect(MideaCoordinatorEntity, SelectEntity):
     def __init__(self,
                  coordinator: MideaDeviceUpdateCoordinator,
                  prop: str,
-                 enum_class: IntEnumHelper) -> None:
+                 enum_class: IntEnumHelper,
+                 translation_key = None) -> None:
         MideaCoordinatorEntity.__init__(self, coordinator)
 
         self._prop = prop
         self._enum_class = enum_class
+        self._attr_translation_key = translation_key
         self._name = prop.replace("_", " ").capitalize()
 
     @property

--- a/custom_components/midea_ac/select.py
+++ b/custom_components/midea_ac/select.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import logging
-
 from typing import List
 
 from homeassistant.components.select import SelectEntity
@@ -34,15 +33,15 @@ async def async_setup_entry(
     entities = []
     if getattr(coordinator.device, "supports_vertical_swing_angle", False):
         entities.append(MideaEnumSelect(coordinator,
-                                    "vertical_swing_angle",
-                                    AC.SwingAngle,
-                                    "swing_angle"))
+                                        "vertical_swing_angle",
+                                        AC.SwingAngle,
+                                        "swing_angle"))
 
     if getattr(coordinator.device, "supports_horizontal_swing_angle", False):
         entities.append(MideaEnumSelect(coordinator,
-                                    "horizontal_swing_angle",
-                                    AC.SwingAngle,
-                                    "swing_angle"))
+                                        "horizontal_swing_angle",
+                                        AC.SwingAngle,
+                                        "swing_angle"))
     add_entities(entities)
 
 
@@ -53,7 +52,7 @@ class MideaEnumSelect(MideaCoordinatorEntity, SelectEntity):
                  coordinator: MideaDeviceUpdateCoordinator,
                  prop: str,
                  enum_class: MideaIntEnum,
-                 translation_key = None) -> None:
+                 translation_key=None) -> None:
         MideaCoordinatorEntity.__init__(self, coordinator)
 
         self._prop = prop
@@ -102,9 +101,9 @@ class MideaEnumSelect(MideaCoordinatorEntity, SelectEntity):
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""
-        
-        setattr(self._device, self._prop, self._enum_class.get_from_name(option.upper()))
-        
+
+        setattr(self._device, self._prop,
+                self._enum_class.get_from_name(option.upper()))
+
         # Apply via the coordinator
         await self.coordinator.apply()
-

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -95,6 +95,18 @@
           }
         }
       }
+    },
+    "select": {
+      "swing_angle": {
+        "state": {
+          "off": "Off",
+          "pos_1": "Position 1",
+          "pos_2": "Position 2",
+          "pos_3": "Position 3",
+          "pos_4": "Position 4",
+          "pos_5": "Position 5"
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Add select entities to control the horizontal and vertical swing angle for devices that support the feature.

Requires https://github.com/mill1000/midea-msmart/pull/109

Close #69 