### PR TITLE
Add humidity  and energy sensors

### DIFF
--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -32,6 +32,7 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
         )
 
         self._device = device
+        self._energy_sensors = 0
 
     async def _async_update_data(self) -> None:
         """Update the device data."""
@@ -50,6 +51,20 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
     def device(self) -> AC:
         """Fetch the device object."""
         return self._device
+
+    def register_energy_sensor(self) -> None:
+        """Record that an energy sensor is active."""
+        self._energy_sensors += 1
+
+        # Enable requests
+        self._device.enable_energy_usage_requests = True
+
+    def unregister_energy_sensor(self) -> None:
+        """Record that an energy sensor is inactive."""
+        self._energy_sensors -= 1
+
+        # Disable requests if last sensor
+        self._device.enable_energy_usage_requests = self._energy_sensors > 0
 
 
 class MideaCoordinatorEntity(CoordinatorEntity):

--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng>=2024.5.4"
+    "msmart-ng>=2024.7.1"
   ],
   "version": "2024.7.2"
 }

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -7,7 +7,7 @@ from typing import Optional
 from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature
+from homeassistant.const import UnitOfTemperature, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -29,29 +29,44 @@ async def async_setup_entry(
     # Fetch coordinator from global data
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Create sensor entities
-    add_entities([
-        MideaTemperatureSensor(
-            coordinator,
-            "indoor_temperature",
-            "indoor_temperature"),
-        MideaTemperatureSensor(
-            coordinator,
-            "outdoor_temperature",
-            "outdoor_temperature"),
-    ])
+    entities = [
+        MideaSensor(coordinator,
+                               "indoor_temperature",
+                               SensorDeviceClass.TEMPERATURE,
+                               UnitOfTemperature.CELSIUS,
+                               "indoor_temperature"),
+        MideaSensor(coordinator,
+                               "outdoor_temperature",
+                               SensorDeviceClass.TEMPERATURE,
+                               UnitOfTemperature.CELSIUS,
+                               "outdoor_temperature"),
+    ]
+
+    # TODO missing in msmart-ng
+    if getattr(coordinator.device, "supports_humidity", False):
+        entities.append(MideaSensor(coordinator,
+                            "indoor_humidity",
+                             SensorDeviceClass.HUMIDITY,
+                             PERCENTAGE,
+                            "indoor_humidity"))
+
+    add_entities(entities)
 
 
-class MideaTemperatureSensor(MideaCoordinatorEntity, SensorEntity):
-    """Temperature sensor for Midea AC."""
+class MideaSensor(MideaCoordinatorEntity, SensorEntity):
+    """Generic sensor class for Midea AC."""
 
     def __init__(self,
                  coordinator: MideaDeviceUpdateCoordinator,
                  prop: str,
+                 device_class: SensorDeviceClass,
+                 unit,
                  translation_key: Optional[str] = None) -> None:
         MideaCoordinatorEntity.__init__(self, coordinator)
 
         self._prop = prop
+        self._device_class = device_class
+        self._unit = unit
         self._attr_translation_key = translation_key
 
     @property
@@ -76,18 +91,15 @@ class MideaTemperatureSensor(MideaCoordinatorEntity, SensorEntity):
     @property
     def available(self) -> bool:
         """Check entity availability."""
-        # Sensor is unavailable if device is offline
-        if not super().available:
-            return False
 
-        # Sensor is unavailable if value is None
-        return self.native_value is not None
+        # Sensor is unavailable if device is offline or value is None
+        return self._device.online and self.native_value is not None
 
     @property
     def device_class(self) -> str:
         """Return the device class of this entity."""
-        return SensorDeviceClass.TEMPERATURE
-
+        return self._device_class
+    
     @property
     def state_class(self) -> str:
         """Return the state class of this entity."""
@@ -95,8 +107,8 @@ class MideaTemperatureSensor(MideaCoordinatorEntity, SensorEntity):
 
     @property
     def native_unit_of_measurement(self) -> str:
-        """Return the native units pf this entity."""
-        return UnitOfTemperature.CELSIUS
+        """Return the native units of this entity."""
+        return self._unit
 
     @property
     def native_value(self) -> float | None:

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -7,7 +7,7 @@ from typing import Optional
 from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import UnitOfTemperature, PERCENTAGE
+from homeassistant.const import PERCENTAGE, UnitOfTemperature
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -31,24 +31,24 @@ async def async_setup_entry(
 
     entities = [
         MideaSensor(coordinator,
-                               "indoor_temperature",
-                               SensorDeviceClass.TEMPERATURE,
-                               UnitOfTemperature.CELSIUS,
-                               "indoor_temperature"),
+                    "indoor_temperature",
+                    SensorDeviceClass.TEMPERATURE,
+                    UnitOfTemperature.CELSIUS,
+                    "indoor_temperature"),
         MideaSensor(coordinator,
-                               "outdoor_temperature",
-                               SensorDeviceClass.TEMPERATURE,
-                               UnitOfTemperature.CELSIUS,
-                               "outdoor_temperature"),
+                    "outdoor_temperature",
+                    SensorDeviceClass.TEMPERATURE,
+                    UnitOfTemperature.CELSIUS,
+                    "outdoor_temperature"),
     ]
 
     # TODO missing in msmart-ng
     if getattr(coordinator.device, "supports_humidity", False):
         entities.append(MideaSensor(coordinator,
-                            "indoor_humidity",
-                             SensorDeviceClass.HUMIDITY,
-                             PERCENTAGE,
-                            "indoor_humidity"))
+                                    "indoor_humidity",
+                                    SensorDeviceClass.HUMIDITY,
+                                    PERCENTAGE,
+                                    "indoor_humidity"))
 
     add_entities(entities)
 
@@ -99,7 +99,7 @@ class MideaSensor(MideaCoordinatorEntity, SensorEntity):
     def device_class(self) -> str:
         """Return the device class of this entity."""
         return self._device_class
-    
+
     @property
     def state_class(self) -> str:
         """Return the state class of this entity."""

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -42,7 +42,6 @@ async def async_setup_entry(
                     "outdoor_temperature"),
     ]
 
-    # TODO missing in msmart-ng
     if getattr(coordinator.device, "supports_humidity", False):
         entities.append(MideaSensor(coordinator,
                                     "indoor_humidity",

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -131,6 +131,9 @@
       }
     },
     "sensor": {
+      "indoor_humidity": {
+        "name": "Indoor humidity"
+      },
       "indoor_temperature": {
         "name": "Indoor temperature"
       },

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -131,6 +131,9 @@
       }
     },
     "sensor": {
+      "current_energy_usage": {
+        "name": "Current energy"
+      },
       "indoor_humidity": {
         "name": "Indoor humidity"
       },
@@ -139,6 +142,12 @@
       },
       "outdoor_temperature": {
         "name": "Outdoor temperature"
+      },
+      "real_time_power_usage": {
+        "name": "Power"
+      },
+      "total_energy_usage": {
+        "name": "Total energy"
       }
     },
     "switch": {


### PR DESCRIPTION
Add humidity and energy sensors for supported devices.

Energy sensors are disabled by default and must be enabled.

Close #5 
Close #86 

Indirectly close #81, as msmart-ng 2024.7.1 will suppress those warnings.