### PR TITLE
Revert "Change filter alert entity category so it can be used in area cards"

### DIFF
--- a/custom_components/midea_ac/binary_sensor.py
+++ b/custom_components/midea_ac/binary_sensor.py
@@ -35,7 +35,7 @@ async def async_setup_entry(
         add_entities([MideaBinarySensor(coordinator,
                                         "filter_alert",
                                         BinarySensorDeviceClass.PROBLEM,
-                                        EntityCategory.CONFIG,
+                                        EntityCategory.DIAGNOSTIC,
                                         "filter_alert"
                                         )])
 


### PR DESCRIPTION
Reverts mill1000/midea-ac-py#176

CONFIG is not valid for a binary sensor