### PR TITLE
Add self/active clean support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ See [Getting Device Info](#getting-device-info) to determine if a device is supp
 * Select entities to control swing angle when supported.
 * Indoor humidity sensor when supported.
 * Energy and power sensors when supported<sup>3</sup>.
+* Button and binary sensor to start & monitor self cleaning.
 * Translations
   * български
   * Català

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -18,6 +18,7 @@ from .coordinator import MideaDeviceUpdateCoordinator
 _LOGGER = logging.getLogger(__name__)
 _PLATFORMS = [
     Platform.BINARY_SENSOR,
+    Platform.BUTTON,
     Platform.CLIMATE,
     Platform.NUMBER,
     Platform.SELECT,

--- a/custom_components/midea_ac/binary_sensor.py
+++ b/custom_components/midea_ac/binary_sensor.py
@@ -32,11 +32,11 @@ async def async_setup_entry(
     # Create entities for supported features
     entities = []
     if getattr(coordinator.device, "supports_filter_reminder", False):
-        add_entities([MideaBinarySensor(coordinator,
-                                        "filter_alert",
-                                        BinarySensorDeviceClass.PROBLEM,
-                                        "filter_alert"
-                                        )])
+        entities.append(MideaBinarySensor(coordinator,
+                                          "filter_alert",
+                                          BinarySensorDeviceClass.PROBLEM,
+                                          "filter_alert"
+                                          ))
 
     if getattr(coordinator.device, "supports_self_clean", False):
         entities.append(MideaBinarySensor(coordinator,

--- a/custom_components/midea_ac/binary_sensor.py
+++ b/custom_components/midea_ac/binary_sensor.py
@@ -29,13 +29,23 @@ async def async_setup_entry(
     # Fetch coordinator from global data
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Create sensor entities from device if supported
+    # Create entities for supported features
+    entities = []
     if getattr(coordinator.device, "supports_filter_reminder", False):
         add_entities([MideaBinarySensor(coordinator,
                                         "filter_alert",
                                         BinarySensorDeviceClass.PROBLEM,
                                         "filter_alert"
                                         )])
+
+    if getattr(coordinator.device, "supports_self_clean", False):
+        entities.append(MideaBinarySensor(coordinator,
+                                          "self_clean_active",
+                                          BinarySensorDeviceClass.RUNNING,
+                                          "self_clean",
+                                          entity_category=EntityCategory.DIAGNOSTIC,
+                                          ))
+    add_entities(entities)
 
 
 class MideaBinarySensor(MideaCoordinatorEntity, BinarySensorEntity):

--- a/custom_components/midea_ac/button.py
+++ b/custom_components/midea_ac/button.py
@@ -1,0 +1,84 @@
+"""Button platform for Midea Smart AC."""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from homeassistant.components.button import ButtonEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import MideaCoordinatorEntity, MideaDeviceUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    config_entry: ConfigEntry,
+    add_entities: AddEntitiesCallback,
+) -> None:
+    """Setup the button platform for Midea Smart AC."""
+
+    _LOGGER.info("Setting up button platform.")
+
+    # Fetch coordinator from global data
+    coordinator = hass.data[DOMAIN][config_entry.entry_id]
+
+    # Create entities for supported features
+    entities = []
+    if getattr(coordinator.device, "supports_self_clean", False):
+        entities.append(MideaButton(coordinator,
+                                           "start_self_clean",
+                                           EntityCategory.DIAGNOSTIC,
+                                           "self_clean"
+                                           ))
+    add_entities(entities)
+
+
+class MideaButton(MideaCoordinatorEntity, ButtonEntity):
+    """Button for Midea AC."""
+
+    def __init__(self,
+                 coordinator: MideaDeviceUpdateCoordinator,
+                 method: str,
+                 entity_category: EntityCategory,
+                 translation_key: Optional[str] = None) -> None:
+        MideaCoordinatorEntity.__init__(self, coordinator)
+
+        self._method = method
+        self._entity_category = entity_category
+        self._attr_translation_key = translation_key
+
+    @property
+    def device_info(self) -> dict:
+        """Return info for device registry."""
+        return {
+            "identifiers": {
+                (DOMAIN, self._device.id)
+            },
+        }
+
+    @property
+    def has_entity_name(self) -> bool:
+        """Indicates if entity follows naming conventions."""
+        return True
+
+    @property
+    def unique_id(self) -> str:
+        """Return the unique ID of this entity."""
+        return f"{self._device.id}-{self._prop}"
+
+    @property
+    def entity_category(self) -> str:
+        """Return the entity category of this entity."""
+        return self._entity_category
+
+    async def async_press(self) -> None:
+        """Handle the button press."""
+        # Call the buttons method
+        if method := getattr(self._device, self._method, None):
+            await method()

--- a/custom_components/midea_ac/button.py
+++ b/custom_components/midea_ac/button.py
@@ -32,10 +32,10 @@ async def async_setup_entry(
     entities = []
     if getattr(coordinator.device, "supports_self_clean", False):
         entities.append(MideaButton(coordinator,
-                                           "start_self_clean",
-                                           EntityCategory.DIAGNOSTIC,
-                                           "self_clean"
-                                           ))
+                                    "start_self_clean",
+                                    "self_clean",
+                                    entity_category=EntityCategory.DIAGNOSTIC,
+                                    ))
     add_entities(entities)
 
 
@@ -45,8 +45,9 @@ class MideaButton(MideaCoordinatorEntity, ButtonEntity):
     def __init__(self,
                  coordinator: MideaDeviceUpdateCoordinator,
                  method: str,
-                 entity_category: EntityCategory,
-                 translation_key: Optional[str] = None) -> None:
+                 translation_key: Optional[str] = None,
+                 *,
+                 entity_category: EntityCategory = None) -> None:
         MideaCoordinatorEntity.__init__(self, coordinator)
 
         self._method = method

--- a/custom_components/midea_ac/button.py
+++ b/custom_components/midea_ac/button.py
@@ -70,7 +70,7 @@ class MideaButton(MideaCoordinatorEntity, ButtonEntity):
     @property
     def unique_id(self) -> str:
         """Return the unique ID of this entity."""
-        return f"{self._device.id}-{self._prop}"
+        return f"{self._device.id}-{self._method}"
 
     @property
     def entity_category(self) -> str:

--- a/custom_components/midea_ac/icons.json
+++ b/custom_components/midea_ac/icons.json
@@ -1,5 +1,10 @@
 {
   "entity": {
+    "binary_sensor": {
+      "self_clean": {
+        "default": "mdi:spray-bottle"
+      }
+    },
     "number": {
       "fan_speed": {
         "default": "mdi:fan"

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -105,6 +105,11 @@
         "name": "Self clean"
       }
     },
+    "button": {
+      "self_clean": {
+        "name": "Start self clean"
+      }
+    },
     "number": {
       "fan_speed": {
         "name": "Fan speed"

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -100,6 +100,9 @@
     "binary_sensor": {
       "filter_alert": {
         "name": "Filter alert"
+      },
+      "self_clean": {
+        "name": "Self clean"
       }
     },
     "number": {


### PR DESCRIPTION
Add button and binary sensor for active/self clean function of supported devices.

Requires https://github.com/mill1000/midea-msmart/pull/149

Untested