### PR TITLE
Switch real time power unit to Watts

### DIFF
--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -68,7 +68,7 @@ async def async_setup_entry(
         entities.append(MideaEnergySensor(coordinator,
                                           "real_time_power_usage",
                                           SensorDeviceClass.POWER,
-                                          UnitOfPower.KILO_WATT,
+                                          UnitOfPower.WATT,
                                           "real_time_power_usage"))
 
     add_entities(entities)


### PR DESCRIPTION
Incorrect assumed it was in KW due to a comment in the reference code.

Close #194 