### PR TITLE
Add gear/rate select support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ See [Getting Device Info](#getting-device-info) to determine if a device is supp
 * Target humidity in Dry mode when supported.
 * Energy and power sensors when supported<sup>3</sup>.
 * Button and binary sensor to start & monitor self cleaning.
+* Select entities for rate select (gear) modes when supported.
 * Translations
   * български
   * Català

--- a/custom_components/midea_ac/icons.json
+++ b/custom_components/midea_ac/icons.json
@@ -14,6 +14,9 @@
       "horizontal_swing_angle": {
         "default": "mdi:angle-acute"
       },
+      "rate_select": {
+        "default": "mdi:slope-downhill"
+      },
       "vertical_swing_angle": {
         "default": "mdi:angle-acute"
       }

--- a/custom_components/midea_ac/select.py
+++ b/custom_components/midea_ac/select.py
@@ -42,6 +42,16 @@ async def async_setup_entry(
                                         "horizontal_swing_angle",
                                         AC.SwingAngle,
                                         "horizontal_swing_angle"))
+
+    supported_rates = getattr(
+        coordinator.device, "supported_rate_selects", [AC.RateSelect.OFF])
+    if supported_rates is not [AC.RateSelect.OFF]:
+        entities.append(MideaEnumSelect(coordinator,
+                                        "rate_select",
+                                        AC.RateSelect,
+                                        "rate_select",
+                                        options=supported_rates))
+
     add_entities(entities)
 
 
@@ -52,12 +62,15 @@ class MideaEnumSelect(MideaCoordinatorEntity, SelectEntity):
                  coordinator: MideaDeviceUpdateCoordinator,
                  prop: str,
                  enum_class: MideaIntEnum,
-                 translation_key: Optional[str] = None) -> None:
+                 translation_key: Optional[str] = None,
+                 *,
+                 options: Optional[List[MideaIntEnum]] = None) -> None:
         MideaCoordinatorEntity.__init__(self, coordinator)
 
         self._prop = prop
         self._enum_class = enum_class
         self._attr_translation_key = translation_key
+        self._options = options
 
     @property
     def device_info(self) -> dict:
@@ -91,7 +104,8 @@ class MideaEnumSelect(MideaCoordinatorEntity, SelectEntity):
     @property
     def options(self) -> List[str]:
         """Get available options."""
-        return [m.name.lower() for m in self._enum_class.list()]
+        opts = self._options if self._options is not None else self._enum_class.list()
+        return [m.name.lower() for m in opts]
 
     async def async_select_option(self, option: str) -> None:
         """Change the selected option."""

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -127,6 +127,19 @@
           "pos_5": "Right"
         }
       },
+      "rate_select": {
+        "name": "Rate select",
+        "state": {
+          "off": "Off",
+          "gear_75": "75%",
+          "gear_50": "50%",
+          "level_5": "Level 5",
+          "level_4": "Level 4",
+          "level_3": "Level 3",
+          "level_2": "Level 2",
+          "level_1": "Level 1"
+        }
+      },
       "vertical_swing_angle": {
         "name": "Vertical swing angle",
         "state": {


### PR DESCRIPTION
Adds support for "gear" or "rate select" on supported devices.

Should also support "generator mode" which allows the user to select between 5 levels of power usage.

Requires https://github.com/mill1000/midea-msmart/pull/157