### PR TITLE
Bump msmart-ng to 2024.8.0

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng>=2024.7.3"
+    "msmart-ng>=2024.8.0"
   ],
   "version": "2024.7.11"
 }


### PR DESCRIPTION
Contains necessary updates to support #209 and #205 