### PR TITLE
Add HR translation for "Breeze away", "Breeze mild" and "Breezeless".

### DIFF
--- a/custom_components/midea_ac/translations/hr.json
+++ b/custom_components/midea_ac/translations/hr.json
@@ -160,6 +160,15 @@
       }
     },
     "switch": {
+      "breeze_away": {
+        "name": "Breeze away"
+      },
+      "breeze_mild": {
+        "name": "Breeze mild"
+      },
+      "breezeless": {
+        "name": "Breezeless"
+      },
       "display": {
         "name": "Zaslon"
       },


### PR DESCRIPTION
Becouse no HR words for this type of use words will be in english. If I found something better I will update the translation.

 Changes to be committed:
	modified:   custom_components/midea_ac/translations/hr.json