### PR TITLE
Bump msmart-ng to 2024.8.1

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng>=2024.8.0"
+    "msmart-ng>=2024.8.1"
   ],
   "version": "2024.8.0"
 }


### PR DESCRIPTION
Changes notes from release

## What's Changed
* Catch request exceptions from httpx by @mill1000 in https://github.com/mill1000/midea-msmart/pull/163
* Remove Optional type hint on "supports" properties. by @mill1000 in https://github.com/mill1000/midea-msmart/pull/164
* Fix inability to turn off breeze modes by @mill1000 in https://github.com/mill1000/midea-msmart/pull/165
* Add device-level capabilities tests by @mill1000 in https://github.com/mill1000/midea-msmart/pull/166


**Full Changelog**: https://github.com/mill1000/midea-msmart/compare/2024.8.0...2024.8.1