### PR TITLE
Replace getattr/hasattr usage with direct property access.

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -44,8 +44,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
     device = AC(ip=host, port=port, device_id=int(id))
 
     # Configure the connection lifetime
-    lifetime = config_entry.options.get(CONF_MAX_CONNECTION_LIFETIME)
-    if lifetime is not None and hasattr(device, "set_max_connection_lifetime"):
+    if (lifetime := config_entry.options.get(CONF_MAX_CONNECTION_LIFETIME)) is not None:
         _LOGGER.info(
             "Setting maximum connection lifetime to %s seconds for device ID %s.", lifetime, device.id)
         device.set_max_connection_lifetime(lifetime)

--- a/custom_components/midea_ac/binary_sensor.py
+++ b/custom_components/midea_ac/binary_sensor.py
@@ -31,14 +31,14 @@ async def async_setup_entry(
 
     # Create entities for supported features
     entities = []
-    if getattr(coordinator.device, "supports_filter_reminder", False):
+    if coordinator.device.supports_filter_reminder:
         entities.append(MideaBinarySensor(coordinator,
                                           "filter_alert",
                                           BinarySensorDeviceClass.PROBLEM,
                                           "filter_alert"
                                           ))
 
-    if getattr(coordinator.device, "supports_self_clean", False):
+    if coordinator.device.supports_self_clean:
         entities.append(MideaBinarySensor(coordinator,
                                           "self_clean_active",
                                           BinarySensorDeviceClass.RUNNING,

--- a/custom_components/midea_ac/button.py
+++ b/custom_components/midea_ac/button.py
@@ -30,7 +30,7 @@ async def async_setup_entry(
 
     # Create entities for supported features
     entities = []
-    if getattr(coordinator.device, "supports_self_clean", False):
+    if coordinator.device.supports_self_clean:
         entities.append(MideaButton(coordinator,
                                     "start_self_clean",
                                     "self_clean",

--- a/custom_components/midea_ac/number.py
+++ b/custom_components/midea_ac/number.py
@@ -29,7 +29,7 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     # Create entity if supported
-    if getattr(coordinator.device, "supports_custom_fan_speed", False):
+    if coordinator.device.supports_custom_fan_speed:
         add_entities([MideaFanSpeedNumber(coordinator)])
 
 

--- a/custom_components/midea_ac/select.py
+++ b/custom_components/midea_ac/select.py
@@ -31,21 +31,19 @@ async def async_setup_entry(
 
     # Create entities for supported features
     entities = []
-    if getattr(coordinator.device, "supports_vertical_swing_angle", False):
+    if coordinator.device.supports_vertical_swing_angle:
         entities.append(MideaEnumSelect(coordinator,
                                         "vertical_swing_angle",
                                         AC.SwingAngle,
                                         "vertical_swing_angle"))
 
-    if getattr(coordinator.device, "supports_horizontal_swing_angle", False):
+    if coordinator.device.supports_horizontal_swing_angle:
         entities.append(MideaEnumSelect(coordinator,
                                         "horizontal_swing_angle",
                                         AC.SwingAngle,
                                         "horizontal_swing_angle"))
 
-    supported_rates = getattr(
-        coordinator.device, "supported_rate_selects", [AC.RateSelect.OFF])
-    if supported_rates is not [AC.RateSelect.OFF]:
+    if (supported_rates := coordinator.device.supported_rate_selects) is not [AC.RateSelect.OFF]:
         entities.append(MideaEnumSelect(coordinator,
                                         "rate_select",
                                         AC.RateSelect,

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -31,6 +31,7 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     entities = [
+        # Temperature sensors
         MideaSensor(coordinator,
                     "indoor_temperature",
                     SensorDeviceClass.TEMPERATURE,
@@ -41,35 +42,33 @@ async def async_setup_entry(
                     SensorDeviceClass.TEMPERATURE,
                     UnitOfTemperature.CELSIUS,
                     "outdoor_temperature"),
+
+        # Energy sensors
+        MideaEnergySensor(coordinator,
+                          "total_energy_usage",
+                          SensorDeviceClass.ENERGY,
+                          UnitOfEnergy.KILO_WATT_HOUR,
+                          "total_energy_usage",
+                          state_class=SensorStateClass.TOTAL),
+        MideaEnergySensor(coordinator,
+                          "current_energy_usage",
+                          SensorDeviceClass.ENERGY,
+                          UnitOfEnergy.KILO_WATT_HOUR,
+                          "current_energy_usage",
+                          state_class=SensorStateClass.TOTAL_INCREASING),
+        MideaEnergySensor(coordinator,
+                          "real_time_power_usage",
+                          SensorDeviceClass.POWER,
+                          UnitOfPower.WATT,
+                          "real_time_power_usage")
     ]
 
-    if getattr(coordinator.device, "supports_humidity", False):
+    if coordinator.device.supports_humidity:
         entities.append(MideaSensor(coordinator,
                                     "indoor_humidity",
                                     SensorDeviceClass.HUMIDITY,
                                     PERCENTAGE,
                                     "indoor_humidity"))
-
-    if hasattr(coordinator.device, "enable_energy_usage_requests"):
-        entities.append(MideaEnergySensor(coordinator,
-                                          "total_energy_usage",
-                                          SensorDeviceClass.ENERGY,
-                                          UnitOfEnergy.KILO_WATT_HOUR,
-                                          "total_energy_usage",
-                                          state_class=SensorStateClass.TOTAL))
-
-        entities.append(MideaEnergySensor(coordinator,
-                                          "current_energy_usage",
-                                          SensorDeviceClass.ENERGY,
-                                          UnitOfEnergy.KILO_WATT_HOUR,
-                                          "current_energy_usage",
-                                          state_class=SensorStateClass.TOTAL_INCREASING))
-
-        entities.append(MideaEnergySensor(coordinator,
-                                          "real_time_power_usage",
-                                          SensorDeviceClass.POWER,
-                                          UnitOfPower.WATT,
-                                          "real_time_power_usage"))
 
     add_entities(entities)
 

--- a/custom_components/midea_ac/switch.py
+++ b/custom_components/midea_ac/switch.py
@@ -29,27 +29,28 @@ async def async_setup_entry(
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
     # Add supported switch entities
-    entities = []
-    if hasattr(coordinator.device, "toggle_display"):
-        entities.append(MideaDisplaySwitch(coordinator))
+    entities = [
+        # TODO Check supports_display_control ?
+        MideaDisplaySwitch(coordinator)
+    ]
 
-    if getattr(coordinator.device, "supports_purifier", False):
+    if coordinator.device.supports_purifier:
         entities.append(MideaSwitch(coordinator,
                                     "purifier",
                                     "purifier",
                                     entity_category=EntityCategory.CONFIG))
 
-    if getattr(coordinator.device, "supports_breeze_away", False):
+    if coordinator.device.supports_breeze_away:
         entities.append(MideaSwitch(coordinator,
                                     "breeze_away",
                                     "breeze_away"))
 
-    if getattr(coordinator.device, "supports_breeze_mild", False):
+    if coordinator.device.supports_breeze_mild:
         entities.append(MideaSwitch(coordinator,
                                     "breeze_mild",
                                     "breeze_mild"))
 
-    if getattr(coordinator.device, "supports_breezeless", False):
+    if coordinator.device.supports_breezeless:
         entities.append(MideaSwitch(coordinator,
                                     "breezeless",
                                     "breezeless"))


### PR DESCRIPTION
The original purpose of those was to ensure compatibility with older msmart releases.

Since we are now maintaining msmart-ng we can ensure the properties exist