### PR TITLE
Bump msmart-ng to 2024.9.0

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng>=2024.8.1"
+    "msmart-ng>=2024.9.0"
   ],
   "version": "2024.8.1"
 }


### PR DESCRIPTION
Change notes from msmart-ng 2024.9.0

## What's Changed
* Resolve occasional exceptions in user logs by catching CancelledError by @mill1000 in https://github.com/mill1000/midea-msmart/pull/167
* Use enum for "breeze" mode by @mill1000 in https://github.com/mill1000/midea-msmart/pull/169
* Add IECO support by @mill1000 in https://github.com/mill1000/midea-msmart/pull/162
* Refactor property decode/encode by @mill1000 in https://github.com/mill1000/midea-msmart/pull/170
* Refactor preset properties to avoid "_mode" prefix which may have been conflated with operational modes by @mill1000 in https://github.com/mill1000/midea-msmart/pull/171
* Add alternate energy/power response parsing by @mill1000 in https://github.com/mill1000/midea-msmart/pull/172