### PR TITLE
Rate select should only be visible when device supports more than 1 rate

### DIFF
--- a/custom_components/midea_ac/select.py
+++ b/custom_components/midea_ac/select.py
@@ -43,7 +43,7 @@ async def async_setup_entry(
                                         AC.SwingAngle,
                                         "horizontal_swing_angle"))
 
-    if (supported_rates := coordinator.device.supported_rate_selects) is not [AC.RateSelect.OFF]:
+    if (supported_rates := coordinator.device.supported_rate_selects) != [AC.RateSelect.OFF]:
         entities.append(MideaEnumSelect(coordinator,
                                         "rate_select",
                                         AC.RateSelect,


### PR DESCRIPTION
Due to a misuse of `is not` the rate select entity was being created even if the device did not support rate select