### PR TITLE
Reduce minimium connection lifetime to 15 seconds

### DIFF
--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -25,7 +25,7 @@ from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_BEEP,
                     CONF_ENERGY_FORMAT, CONF_FAN_SPEED_STEP, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME, CONF_SHOW_ALL_PRESETS,
                     CONF_TEMP_STEP, CONF_USE_FAN_ONLY_WORKAROUND, DOMAIN,
-                    EnergyFormat)
+                    UPDATE_INTERVAL, EnergyFormat)
 
 _DEFAULT_OPTIONS = {
     CONF_BEEP: True,
@@ -283,7 +283,7 @@ class MideaOptionsFlow(OptionsFlow):
             vol.Optional(CONF_ADDITIONAL_OPERATION_MODES,
                          description={"suggested_value": options.get(CONF_ADDITIONAL_OPERATION_MODES, None)}): cv.string,
             vol.Optional(CONF_MAX_CONNECTION_LIFETIME,
-                         description={"suggested_value": options.get(CONF_MAX_CONNECTION_LIFETIME, None)}): vol.All(vol.Coerce(int), vol.Range(min=30)),
+                         description={"suggested_value": options.get(CONF_MAX_CONNECTION_LIFETIME, None)}): vol.All(vol.Coerce(int), vol.Range(min=UPDATE_INTERVAL)),
             vol.Optional(CONF_ENERGY_FORMAT,
                          default=options.get(
                              CONF_ENERGY_FORMAT, EnergyFormat.DEFAULT)

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -1,6 +1,7 @@
 from enum import StrEnum, auto
 
 DOMAIN = "midea_ac"
+UPDATE_INTERVAL = 15
 
 CONF_KEY = "k1"
 CONF_BEEP = "prompt_tone"

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
 from msmart.device import AirConditioner as AC
 
-from .const import DOMAIN
+from .const import DOMAIN, UPDATE_INTERVAL
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -22,7 +22,7 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=datetime.timedelta(seconds=15),
+            update_interval=datetime.timedelta(seconds=UPDATE_INTERVAL),
             request_refresh_debouncer=Debouncer(
                 hass,
                 _LOGGER,


### PR DESCRIPTION
Some users needed values less than 30 seconds, effectively creating a new connection for every update. #283 