### PR TITLE
Put a lock around calls to device refresh() to prevent concurrent calls from throwing exceptions

### DIFF
--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -2,6 +2,7 @@
 
 import datetime
 import logging
+from asyncio import Lock
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
@@ -31,12 +32,14 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
             )
         )
 
+        self._lock = Lock()
         self._device = device
         self._energy_sensors = 0
 
     async def _async_update_data(self) -> None:
         """Update the device data."""
-        await self._device.refresh()
+        async with self._lock:
+            await self._device.refresh()
 
     async def apply(self) -> None:
         """Apply changes to the device and update HA state."""

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -38,25 +38,8 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> None:
         """Update the device data."""
-        _LOGGER.debug("Called _async_update_data()")
         async with self._lock:
             await self._device.refresh()
-
-    async def async_request_refresh(self) -> None:
-        _LOGGER.debug("Calling async_request_refresh()")
-        await super().async_request_refresh()
-
-    async def _handle_refresh_interval(self, *args, **kwargs) -> None:
-        _LOGGER.debug("Calling _handle_refresh_interval()")
-        await super()._handle_refresh_interval(*args, **kwargs)
-
-    async def _async_refresh(self, *args, **kwargs) -> None:
-        _LOGGER.debug("Calling _async_refresh()")
-        await super()._async_refresh(*args, **kwargs)
-
-    def _schedule_refresh(self) -> None:
-        _LOGGER.debug("Calling _schedule_refresh()")
-        super()._schedule_refresh()
 
     async def apply(self) -> None:
         """Apply changes to the device and update HA state."""

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -38,8 +38,25 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
 
     async def _async_update_data(self) -> None:
         """Update the device data."""
+        _LOGGER.debug("Called _async_update_data()")
         async with self._lock:
             await self._device.refresh()
+
+    async def async_request_refresh(self) -> None:
+        _LOGGER.debug("Calling async_request_refresh()")
+        await super().async_request_refresh()
+
+    async def _handle_refresh_interval(self, *args, **kwargs) -> None:
+        _LOGGER.debug("Calling _handle_refresh_interval()")
+        await super()._handle_refresh_interval(*args, **kwargs)
+
+    async def _async_refresh(self, *args, **kwargs) -> None:
+        _LOGGER.debug("Calling _async_refresh()")
+        await super()._async_refresh(*args, **kwargs)
+
+    def _schedule_refresh(self) -> None:
+        _LOGGER.debug("Calling _schedule_refresh()")
+        super()._schedule_refresh()
 
     async def apply(self) -> None:
         """Apply changes to the device and update HA state."""

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -62,7 +62,8 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator):
         """Apply changes to the device and update HA state."""
 
         # Apply changes to device
-        await self._device.apply()
+        async with self._lock:
+            await self._device.apply()
 
         # Update state
         await self.async_request_refresh()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -45,7 +45,7 @@ async def _setup_integration(hass: HomeAssistant) -> MockConfigEntry:
 
 def _mock_lan_protocol(lan) -> None:
     """ Mock the LAN protocol object to enable testing."""
-    
+
     # Mock the read_available method so send() will be reached
     lan._read_available = MagicMock()
     lan._read_available.__aiter__.return_value = None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -43,10 +43,29 @@ async def _setup_integration(hass: HomeAssistant) -> MockConfigEntry:
     return mock_config_entry
 
 
-async def test_concurrent_refresh_exception(
+def _mock_lan_protocol(lan) -> None:
+    """ Mock the LAN protocol object to enable testing."""
+    
+    # Mock the read_available method so send() will be reached
+    lan._read_available = MagicMock()
+    lan._read_available.__aiter__.return_value = None
+
+    # Mock connect and protocol objects so network won't be used
+    async def mock_connect():
+        lan._protocol = _LanProtocol()
+        lan._protocol._peer = "127.0.0.1:6444"
+
+        # Mock the transport so connection wil be seen as alive
+        lan._protocol._transport = MagicMock()
+        lan._protocol._transport.is_closing = MagicMock(return_value=False)
+
+    lan._connect = mock_connect
+
+
+async def test_concurrent_network_access_exception(
     hass: HomeAssistant,
 ) -> None:
-    """Test concurrent refreshes can cause an exception."""
+    """Test concurrent network access can cause an exception."""
 
     # Setup the integration
     mock_config_entry = await _setup_integration(hass)
@@ -55,27 +74,35 @@ async def test_concurrent_refresh_exception(
     # Fetch the coordinator
     coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
     device = coordinator.device
-    lan = device._lan
 
-    # Mock the read_available method so send() will be reached
-    lan._read_available = MagicMock()
-    lan._read_available.__aiter__.return_value = None
-
-    # Mock connect and protocol objects so network won't be used
-    lan._connect = AsyncMock()
-    lan._protocol = _LanProtocol()
-    lan._protocol._peer = "127.0.0.1:6444"
-
-    # Mock the transport so connection wil be seen as alive
-    lan._protocol._transport = MagicMock()
-    lan._protocol._transport.is_closing = MagicMock(return_value=False)
+    # Setup a mock LAN protocol
+    _mock_lan_protocol(device._lan)
 
     # logging.getLogger("msmart").setLevel(logging.DEBUG)
     # logging.getLogger("custom_components.midea_ac").setLevel(logging.DEBUG)
 
-    # Check that concurrent calls to network actions can throw
-    with pytest.raises(AttributeError):
-        task1 = asyncio.create_task(coordinator.async_request_refresh())
-        await asyncio.sleep(3)
-        task2 = asyncio.create_task(coordinator.apply())
-        await asyncio.gather(task1, task2)
+    # Patch the asyncio Lock object to be non-functional
+    with (
+            patch.object(coordinator._lock, "acquire",
+                         AsyncMock(return_value=True)),
+            patch.object(coordinator._lock, "locked",
+                         MagicMock(return_value=False)),
+            patch.object(coordinator._lock, "release",
+                         MagicMock(return_value=None))
+    ):
+        # Assert exception is thrown when concurrent access occurs
+        with pytest.raises(AttributeError):
+            task1 = asyncio.create_task(coordinator.async_request_refresh())
+            await asyncio.sleep(3)
+            task2 = asyncio.create_task(coordinator.apply())
+            await asyncio.gather(task1, task2)
+
+    # Reconstruct mock LAN protocol
+    _mock_lan_protocol(device._lan)
+
+    # Check that concurrent calls to network actions don't throw
+    task1 = asyncio.create_task(coordinator.async_request_refresh())
+    await asyncio.sleep(3)
+    task2 = asyncio.create_task(coordinator.apply())
+    await task1
+    task2.cancel()


### PR DESCRIPTION
Possible fix for #300, and may solve some users issues reported in #254 