### PR TITLE
Add support for auxillary heat modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ See [Getting Device Info](#getting-device-info) to determine if a device is supp
   * Rate selection (Gear mode)
   * "Breeze" modes (e.g., breeze away, breeze mild, breezeless)
   * iECO
+  * Auxiliary heating mode
 
 <small>
 

--- a/custom_components/midea_ac/diagnostics.py
+++ b/custom_components/midea_ac/diagnostics.py
@@ -40,6 +40,7 @@ async def async_get_config_entry_diagnostics(
                 "supported_fan_speeds": device.supported_fan_speeds,
                 "supports_custom_fan_speed": device.supports_custom_fan_speed,
                 "supported_rate_selects": device.supported_rate_selects,
+                "supported_aux_modes": device.supported_aux_modes,
 
                 "supports_eco": device.supports_eco,
                 "supports_ieco": device.supports_ieco,

--- a/custom_components/midea_ac/icons.json
+++ b/custom_components/midea_ac/icons.json
@@ -22,6 +22,9 @@
       }
     },
     "select": {
+      "aux_mode": {
+        "default": "mdi:heating-coil"
+      },
       "horizontal_swing_angle": {
         "default": "mdi:angle-acute"
       },

--- a/custom_components/midea_ac/select.py
+++ b/custom_components/midea_ac/select.py
@@ -50,6 +50,13 @@ async def async_setup_entry(
                                         "rate_select",
                                         options=supported_rates))
 
+    if (supported_aux_modes := coordinator.device.supported_aux_modes) != [AC.AuxHeatMode.OFF]:
+        entities.append(MideaEnumSelect(coordinator,
+                                        "aux_mode",
+                                        AC.AuxHeatMode,
+                                        "aux_mode",
+                                        options=supported_aux_modes))
+
     add_entities(entities)
 
 

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -137,6 +137,14 @@
       }
     },
     "select": {
+      "aux_mode": {
+        "name": "Auxiliary heat mode",
+        "state": {
+          "off": "Off",
+          "aux_heat": "Heat & Aux",
+          "aux_only": "Aux only"
+        }
+      },
       "horizontal_swing_angle": {
         "name": "Horizontal swing angle",
         "state": {


### PR DESCRIPTION
Adds select entity for controlling electric auxiliary heat modes.

Close #297 

Requires an update to msmart-ng