### PR TITLE
Bump msmart-ng to 2025.3.1

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2025.2.2"
+    "msmart-ng==2025.3.1"
   ],
   "version": "2025.2.3"
 }


### PR DESCRIPTION
Relevant changes:

* Let cloud errors propagate when fetching tokens during discovery by @mill1000 in https://github.com/mill1000/midea-msmart/pull/203
* Switch to NetHome Plus cloud to restore get_token and discovery functionality by @mill1000 in https://github.com/mill1000/midea-msmart/pull/194
*  Update discovery flow to throw exceptions when cloud connection fails by @mill1000 in https://github.com/mill1000/midea-msmart/pull/197