### PR TITLE
Add a dummy step to the discovery flow to display token & key from device

### DIFF
--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -33,15 +33,11 @@
         }
       },
       "show_token_key": {
-        "description": "Save the following token & key for future use. Any input on this form is discarded.",
+        "description": "Save this token and key for future use.\nAll input on this form is discarded.",
         "data": {
           "id": "ID",
           "token": "Token",
           "k1": "Key"
-        },
-        "data_description": {
-          "token": "Token for V3 devices",
-          "k1": "Key for V3 devices"
         }
       }
     },

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -35,6 +35,7 @@
       "show_token_key": {
         "description": "Save the following token & key for future use. Any input on this form is discarded.",
         "data": {
+          "id": "ID",
           "token": "Token",
           "k1": "Key"
         },
@@ -42,7 +43,7 @@
           "token": "Token for V3 devices",
           "k1": "Key for V3 devices"
         }
-      },
+      }
     },
     "abort": {
       "already_configured": "The device has already been configured.",

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -14,7 +14,7 @@
           "host": "Host",
           "country_code": "Cloud Region"
         },
-        "data_description":{
+        "data_description": {
           "country_code": "Select closest country to your location."
         }
       },
@@ -31,7 +31,18 @@
           "token": "Token for V3 devices",
           "k1": "Key for V3 devices"
         }
-      }
+      },
+      "show_token_key": {
+        "description": "Save the following token & key for future use. Any input on this form is discarded.",
+        "data": {
+          "token": "Token",
+          "k1": "Key"
+        },
+        "data_description": {
+          "token": "Token for V3 devices",
+          "k1": "Key for V3 devices"
+        }
+      },
     },
     "abort": {
       "already_configured": "The device has already been configured.",


### PR DESCRIPTION
Add a new dummy step to the discovery config flow that displays the device's ID, token and key. Users should copy this information to a safe place in case the cloud service goes offline.

All user input on this form is discarded.

![image](https://github.com/user-attachments/assets/d40a4acb-de8c-422c-b201-e884e3c53ada)

Close #331 