### PR TITLE
Bump msmart-ng to 2025.3.3

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2025.3.1"
+    "msmart-ng==2025.3.3"
   ],
   "version": "2025.3.0"
 }


### PR DESCRIPTION
Should close #148 

## What's Changed
* Fixed calculation of temperature with decimals by @gaspo in https://github.com/mill1000/midea-msmart/pull/177
* Update pyproject licensing to be compliant with PEP 639 by @mill1000 in https://github.com/mill1000/midea-msmart/pull/209