### PR TITLE
Introduce ALTERNATE_C

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ Name | Default | Description
 **Show All Presets** | False | Show all presets regardless of device's reported capabilities.
 **Additional Operation Modes** | Empty | Additional HVAC modes to make available in case the device's capabilities are incorrect.
 **Maximum Connection Lifetime** | Empty | Limit the time (in seconds) a connection to the device will be used before reconnecting. If left blank, the connection will persist indefinitely. If your device disconnects at regular intervals, set this to a value below the interval.
-**Energy Format** | Default | Select alternative data formats for decoding energy and power data from the device.<br> Options: <ul><li>`Default` - BCD format</li><li>`Alternate A` - Binary format</li><li>`Alternate B` - Binary format, energy scaled by 1/10</li></ul>
+**Energy Format** | Default | Select alternative data formats for decoding energy and power data from the device.<br> Options: <ul><li>`Default` - BCD format</li><li>`Alternate A` - Binary format</li><li>`Alternate B` - Binary format, energy scaled by 1/10</li><li>`Alternate C` - Binary format, energy reported from unit in W</li></ul>
 **Reverse Horizontal Swing Angle** | False | Reverse the order of horizontal swing angles from left-to-right to right-to-left.
 
 ## Resolving Connectivity Issues

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -23,3 +23,4 @@ class EnergyFormat(StrEnum):
     DEFAULT = auto()
     ALTERNATE_A = auto()
     ALTERNATE_B = auto()
+    ALTERNATE_C = auto()

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -30,10 +30,11 @@ async def async_setup_entry(
     # Fetch coordinator from global data
     coordinator = hass.data[DOMAIN][config_entry.entry_id]
 
-    # Configure energy format
-    energy_scale = 1.0
+    # Configure energy units
+    unit_of_energy = UnitOfEnergy.KILO_WATT_HOUR
+
     if config_entry.options.get(CONF_ENERGY_FORMAT) == EnergyFormat.ALTERNATE_B:
-        energy_scale = .1
+        unit_of_energy = UnitOfEnergy.WATT_HOUR
 
     entities = [
         # Temperature sensors
@@ -52,17 +53,15 @@ async def async_setup_entry(
         MideaEnergySensor(coordinator,
                           "total_energy_usage",
                           SensorDeviceClass.ENERGY,
-                          UnitOfEnergy.KILO_WATT_HOUR,
+                          unit_of_energy,
                           "total_energy_usage",
-                          state_class=SensorStateClass.TOTAL,
-                          scale=energy_scale),
+                          state_class=SensorStateClass.TOTAL),
         MideaEnergySensor(coordinator,
                           "current_energy_usage",
                           SensorDeviceClass.ENERGY,
-                          UnitOfEnergy.KILO_WATT_HOUR,
+                          unit_of_energy,
                           "current_energy_usage",
-                          state_class=SensorStateClass.TOTAL_INCREASING,
-                          scale=energy_scale),
+                          state_class=SensorStateClass.TOTAL_INCREASING),
         MideaEnergySensor(coordinator,
                           "real_time_power_usage",
                           SensorDeviceClass.POWER,

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -32,8 +32,11 @@ async def async_setup_entry(
 
     # Configure energy units
     unit_of_energy = UnitOfEnergy.KILO_WATT_HOUR
+    energy_scale = 1.0
 
     if config_entry.options.get(CONF_ENERGY_FORMAT) == EnergyFormat.ALTERNATE_B:
+        energy_scale = 0.1
+    elif config_entry.options.get(CONF_ENERGY_FORMAT) == EnergyFormat.ALTERNATE_C:
         unit_of_energy = UnitOfEnergy.WATT_HOUR
 
     entities = [
@@ -55,13 +58,15 @@ async def async_setup_entry(
                           SensorDeviceClass.ENERGY,
                           unit_of_energy,
                           "total_energy_usage",
-                          state_class=SensorStateClass.TOTAL),
+                          state_class=SensorStateClass.TOTAL,
+                          scale=energy_scale),
         MideaEnergySensor(coordinator,
                           "current_energy_usage",
                           SensorDeviceClass.ENERGY,
                           unit_of_energy,
                           "current_energy_usage",
-                          state_class=SensorStateClass.TOTAL_INCREASING),
+                          state_class=SensorStateClass.TOTAL_INCREASING,
+                          scale=energy_scale),
         MideaEnergySensor(coordinator,
                           "real_time_power_usage",
                           SensorDeviceClass.POWER,

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -82,7 +82,8 @@
       "options": {
         "default": "Default",
         "alternate_a": "Alternate A",
-        "alternate_b": "Alternate B"
+        "alternate_b": "Alternate B",
+        "alternate_c": "Alternate C"
       }
     }
   },


### PR DESCRIPTION
Partially closes https://github.com/mill1000/midea-ac-py/issues/344 

## Changes
- Updates units for energy based sensors to report watt-hours when ALTERNATE_B is selected in the options

Disclaimer: While I'm confident this is the solution for my particular unit, I'm not sure if there are people reliant on ALTERNATE_B where the unit reports data in a different unit or scale. This may be a wildly inappropriate treatment - and in fact, it may be better to introduce ALTERNATE_C and treat it that way instead. I'm happy to have a poke at that change if you'd prefer it @mill1000 

I couldn't see any mention of these in the tess that are present, so I've not included any modifications there.