### PR TITLE
Bump msmart-ng to 2025.5.0

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2025.3.3"
+    "msmart-ng==2025.5.0"
   ],
   "version": "2025.4.0"
 }


### PR DESCRIPTION
Release notes from msmart-ng 2025.5.0
* Fix incorrect payload in get_capabilities() log output by @mill1000 in https://github.com/mill1000/midea-msmart/pull/214
* Update command unit tests to check for newer class properties by @mill1000 in https://github.com/mill1000/midea-msmart/pull/215
* Add support for "Flash Cool" AKA Jet Cool. by @mill1000 in https://github.com/mill1000/midea-msmart/pull/212
* Downgrade "Unknown capability ID" message to INFO by @mill1000 in https://github.com/mill1000/midea-msmart/pull/216
* Add additional Discover flow tests by @mill1000 in https://github.com/mill1000/midea-msmart/pull/217
