### PR TITLE
Bump msmart-ng to 2025.9.0

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2025.7.0"
+    "msmart-ng==2025.9.0"
   ],
   "version": "2025.7.0"
 }


### PR DESCRIPTION
Required to support #371 

# msmart-ng 2025.9.0
## What's Changed
* Fix bad Cascade unit test by @mill1000 in https://github.com/mill1000/midea-msmart/pull/227
* Skip Cloud tests when running on CI by @mill1000 in https://github.com/mill1000/midea-msmart/pull/226
* Use class instead of ID to filter for specific responses by @mill1000 in https://github.com/mill1000/midea-msmart/pull/228
* Raise exceptions on connection lost events by @mill1000 in https://github.com/mill1000/midea-msmart/pull/229
* Add support for accessing individual energy data fields in either format by @mill1000 in https://github.com/mill1000/midea-msmart/pull/230
