### PR TITLE
Reject unsupported devices during manual configuration

### DIFF
--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -268,12 +268,12 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Attempt a connection to see if config is valid
                 device = await self._test_manual_connection(user_input)
 
-                if device and device.supported == False:
-                    # Indicate unsupported device type
-                    errors["base"] = "unsupported_device"
-                elif not device or device.online == False:
+                if not device or device.online == False:
                     # Indicate a connection could not be made
                     errors["base"] = "cannot_connect"
+                elif device and device.supported == False:
+                    # Indicate unsupported device type
+                    errors["base"] = "unsupported_device"
                 else:
                     # Create entry from valid device
                     return await self._create_entry_from_device(device)
@@ -320,12 +320,12 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Attempt a connection to see if config is valid
                 device = await self._test_manual_connection(user_input)
 
-                if device and device.supported == False:
-                    # Indicate unsupported device type
-                    errors["base"] = "unsupported_device"
-                elif not device or device.online == False:
+                if not device or device.online == False:
                     # Indicate a connection could not be made
                     errors["base"] = "cannot_connect"
+                elif device and device.supported == False:
+                    # Indicate unsupported device type
+                    errors["base"] = "unsupported_device"
                 else:
                     # Update entry
                     return self.async_update_reload_and_abort(

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -268,11 +268,15 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Attempt a connection to see if config is valid
                 device = await self._test_manual_connection(user_input)
 
-                if device:
+                if not device:
+                    # Indicate a connection could not be made
+                    errors["base"] = "cannot_connect"
+                elif device.type != DeviceType.AIR_CONDITIONER:
+                    # Indicate unsupported device type
+                    errors["base"] = "unsupported_device"
+                else:
+                    # Create entry from valid device
                     return await self._create_entry_from_device(device)
-
-                # Indicate a connection could not be made
-                errors["base"] = "cannot_connect"
 
         user_input = user_input or {}
 
@@ -316,14 +320,18 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 # Attempt a connection to see if config is valid
                 device = await self._test_manual_connection(user_input)
 
-                if device:
+                if not device:
+                    # Indicate a connection could not be made
+                    errors["base"] = "cannot_connect"
+                elif device.type != DeviceType.AIR_CONDITIONER:
+                    # Indicate unsupported device type
+                    errors["base"] = "unsupported_device"
+                else:
+                    # Update entry
                     return self.async_update_reload_and_abort(
                         self._get_reconfigure_entry(),
                         data_updates=user_input,
                     )
-
-                # Indicate a connection could not be made
-                errors["base"] = "cannot_connect"
 
         # Use existing config entry data if no user input
         user_input = user_input or self._get_reconfigure_entry().data

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,7 +1,7 @@
 """Tests for the config flow."""
 
 import logging
-from unittest.mock import patch
+from unittest.mock import AsyncMock, PropertyMock, patch
 
 import pytest
 from homeassistant import config_entries
@@ -46,8 +46,9 @@ async def test_config_flow_options(hass: HomeAssistant) -> None:
     assert not manual_form_result["errors"]
 
 
-async def test_manual_flow(hass: HomeAssistant) -> None:
-    """Test the manual flow validates input and failed connections return errors."""
+async def test_manual_flow_invalid_input(hass: HomeAssistant) -> None:
+    """Test the manual flow validates input."""
+    # Start the flow
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "manual"}
     )
@@ -74,50 +75,6 @@ async def test_manual_flow(hass: HomeAssistant) -> None:
                 user_input=input
             )
 
-    with (patch("custom_components.midea_ac.config_flow.AC.refresh",
-                return_value=False) as refresh_mock,
-          patch("custom_components.midea_ac.config_flow.AC.authenticate",
-                side_effect=AuthenticationError) as authenticate_mock):
-        # Check manually configuring a V2 device
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "localhost",
-                CONF_PORT: 6444,
-                CONF_ID: "1234"
-            }
-        )
-        assert result
-        # Refresh should be called
-        refresh_mock.assert_awaited_once()
-        # Authenticate shouldn't be called
-        authenticate_mock.assert_not_awaited()
-        # Connection should fail
-        assert result["errors"] == {"base": "cannot_connect"}
-
-        refresh_mock.reset_mock()
-        authenticate_mock.reset_mock()
-
-        # Check manually configuring a V3 device
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "localhost",
-                CONF_PORT: 6444,
-                CONF_ID: "1234",
-                CONF_TOKEN: "1234",
-                CONF_KEY: "1234"
-
-            }
-        )
-        assert result
-        # Authenticate should be called
-        authenticate_mock.assert_awaited_once()
-        # Refresh should be not called
-        refresh_mock.assert_not_awaited()
-        # Connection should fail
-        assert result["errors"] == {"base": "cannot_connect"}
-
     # Check that invalid token/keys formats throw an error
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -131,15 +88,104 @@ async def test_manual_flow(hass: HomeAssistant) -> None:
         }
     )
     assert result
-    # Authenticate should be called
-    authenticate_mock.assert_awaited_once()
-    # Refresh should be not called
-    refresh_mock.assert_not_awaited()
+
     # Inputs should be marked as invalid
     assert result["errors"] == {
         CONF_TOKEN: "invalid_hex_format",
         CONF_KEY: "invalid_hex_format"
     }
+
+
+async def test_manual_flow_cant_connect(hass: HomeAssistant) -> None:
+    """Test the manual flow returns error when connection fails."""
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "manual"}
+    )
+    assert result
+
+    # Check manually configuring a V2 device
+    with (
+        patch("custom_components.midea_ac.config_flow.AC.refresh") as refresh_mock,
+        patch("custom_components.midea_ac.config_flow.AC.authenticate", side_effect=AuthenticationError) as authenticate_mock
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "localhost",
+                CONF_PORT: 6444,
+                CONF_ID: "1234"
+            }
+        )
+        assert result
+
+        # Refresh should be called
+        refresh_mock.assert_awaited_once()
+
+        # Authenticate shouldn't be called
+        authenticate_mock.assert_not_awaited()
+
+        # Connection should fail
+        assert result["errors"] == {"base": "cannot_connect"}
+
+    # Check manually configuring a V3 device
+    with (
+        patch("custom_components.midea_ac.config_flow.AC.refresh") as refresh_mock,
+        patch("custom_components.midea_ac.config_flow.AC.authenticate", side_effect=AuthenticationError) as authenticate_mock
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "localhost",
+                CONF_PORT: 6444,
+                CONF_ID: "1234",
+                CONF_TOKEN: "1234",
+                CONF_KEY: "1234"
+
+            }
+        )
+        assert result
+
+        # Authenticate should be called
+        authenticate_mock.assert_awaited_once()
+
+        # Refresh should be not called
+        refresh_mock.assert_not_awaited()
+
+        # Connection should fail
+        assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_manual_flow_unsupported_device(hass: HomeAssistant) -> None:
+    """Test the manual flow when an unsupported device is configured."""
+    # Start the flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "manual"}
+    )
+    assert result
+
+    # Test configuring a device that is unsupported
+    with patch("custom_components.midea_ac.config_flow.AC", autospec=True) as mock_ac:
+        device = mock_ac.return_value
+        device.refresh = AsyncMock()
+        type(device).type = PropertyMock(return_value=0xBAD)
+
+        # Manually configure a device
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "localhost",
+                CONF_PORT: 6444,
+                CONF_ID: "1234"
+            }
+        )
+        assert result
+
+        # Refresh should be called
+        device.refresh.assert_awaited_once()
+
+        # Connection should fail
+        assert result["errors"] == {"base": "unsupported_device"}
 
 
 async def test_options_flow_init(hass: HomeAssistant) -> None:
@@ -191,8 +237,8 @@ async def test_options_flow_init(hass: HomeAssistant) -> None:
     assert len(mock_setup_entry.mock_calls) == 1
 
 
-async def test_reconfigure_flow(hass: HomeAssistant) -> None:
-    """Test the reconfigure flow validates input and failed connections return errors."""
+async def test_reconfigure_flow_invalid_input(hass: HomeAssistant) -> None:
+    """Test the reconfigure flow validates input."""
 
     # Create a mock config entry
     mock_config_entry = MockConfigEntry(
@@ -241,48 +287,6 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
                 user_input=input
             )
 
-    with (patch("custom_components.midea_ac.config_flow.AC.refresh",
-                return_value=False) as refresh_mock,
-          patch("custom_components.midea_ac.config_flow.AC.authenticate",
-                side_effect=AuthenticationError) as authenticate_mock):
-        # Check manually configuring a V2 device
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "localhost",
-                CONF_PORT: 6444,
-            }
-        )
-        assert result
-        # Refresh should be called
-        refresh_mock.assert_awaited_once()
-        # Authenticate shouldn't be called
-        authenticate_mock.assert_not_awaited()
-        # Connection should fail
-        assert result["errors"] == {"base": "cannot_connect"}
-
-        refresh_mock.reset_mock()
-        authenticate_mock.reset_mock()
-
-        # Check manually configuring a V3 device
-        result = await hass.config_entries.flow.async_configure(
-            result["flow_id"],
-            user_input={
-                CONF_HOST: "localhost",
-                CONF_PORT: 6444,
-                CONF_TOKEN: "1234",
-                CONF_KEY: "1234"
-
-            }
-        )
-        assert result
-        # Authenticate should be called
-        authenticate_mock.assert_awaited_once()
-        # Refresh should be not called
-        refresh_mock.assert_not_awaited()
-        # Connection should fail
-        assert result["errors"] == {"base": "cannot_connect"}
-
     # Check that invalid token/keys formats throw an error
     result = await hass.config_entries.flow.async_configure(
         result["flow_id"],
@@ -295,12 +299,149 @@ async def test_reconfigure_flow(hass: HomeAssistant) -> None:
         }
     )
     assert result
-    # Authenticate should be called
-    authenticate_mock.assert_awaited_once()
-    # Refresh should be not called
-    refresh_mock.assert_not_awaited()
+
     # Inputs should be marked as invalid
     assert result["errors"] == {
         CONF_TOKEN: "invalid_hex_format",
         CONF_KEY: "invalid_hex_format"
     }
+
+
+async def test_reconfigure_flow_cant_connect(hass: HomeAssistant) -> None:
+    """Test the reconfigure flow returns error when connection fails."""
+
+    # Create a mock config entry
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ID: "1234",
+            CONF_HOST: "localhost",
+            CONF_PORT: 6444,
+            CONF_TOKEN: None,
+            CONF_KEY: None,
+        }
+    )
+
+    # Patch refresh and get_capabilities calls to allow integration to setup
+    with (patch("custom_components.midea_ac.config_flow.AC.get_capabilities"),
+          patch("custom_components.midea_ac.config_flow.AC.refresh")):
+        # Add mock config entry to HASS and setup integration
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.entry_id in hass.data[DOMAIN]
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": mock_config_entry.entry_id,
+        }
+    )
+    assert result
+
+    # Check reconfiguring a V2 device
+    with (
+        patch("custom_components.midea_ac.config_flow.AC.refresh") as refresh_mock,
+        patch("custom_components.midea_ac.config_flow.AC.authenticate", side_effect=AuthenticationError) as authenticate_mock
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "localhost",
+                CONF_PORT: 6444,
+            }
+        )
+        assert result
+
+        # Refresh should be called
+        refresh_mock.assert_awaited_once()
+
+        # Authenticate shouldn't be called
+        authenticate_mock.assert_not_awaited()
+
+        # Connection should fail
+        assert result["errors"] == {"base": "cannot_connect"}
+
+    # Check reconfiguring a V3 device
+    with (
+        patch("custom_components.midea_ac.config_flow.AC.refresh") as refresh_mock,
+        patch("custom_components.midea_ac.config_flow.AC.authenticate", side_effect=AuthenticationError) as authenticate_mock
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "localhost",
+                CONF_PORT: 6444,
+                CONF_TOKEN: "1234",
+                CONF_KEY: "1234"
+
+            }
+        )
+        assert result
+
+        # Authenticate should be called
+        authenticate_mock.assert_awaited_once()
+
+        # Refresh should be not called
+        refresh_mock.assert_not_awaited()
+
+        # Connection should fail
+        assert result["errors"] == {"base": "cannot_connect"}
+
+
+async def test_reconfigure_flow_unsupported_device(hass: HomeAssistant) -> None:
+    """Test the reconfigure flow when an unsupported device is configured."""
+
+    # Create a mock config entry
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_ID: "1234",
+            CONF_HOST: "localhost",
+            CONF_PORT: 6444,
+            CONF_TOKEN: None,
+            CONF_KEY: None,
+        }
+    )
+
+    # Patch refresh and get_capabilities calls to allow integration to setup
+    with (patch("custom_components.midea_ac.config_flow.AC.get_capabilities"),
+          patch("custom_components.midea_ac.config_flow.AC.refresh")):
+        # Add mock config entry to HASS and setup integration
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.entry_id in hass.data[DOMAIN]
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={
+            "source": config_entries.SOURCE_RECONFIGURE,
+            "entry_id": mock_config_entry.entry_id,
+        }
+    )
+    assert result
+
+    with patch("custom_components.midea_ac.config_flow.AC", autospec=True) as mock_ac:
+        device = mock_ac.return_value
+        device.refresh = AsyncMock()
+        type(device).type = PropertyMock(return_value=0xBAD)
+
+        # Manually configure a device
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "localhost",
+                CONF_PORT: 6444,
+            }
+        )
+        assert result
+
+        # Refresh should be called
+        device.refresh.assert_awaited_once()
+
+        # Connection should fail
+        assert result["errors"] == {"base": "unsupported_device"}


### PR DESCRIPTION
In #374 a user configured an unsupported device type. I don't know for sure if it was via the manual flow but we should try to prevent this.

Close #377 
