### PR TITLE
Add error code to device state attributes

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -234,7 +234,8 @@ class MideaClimateACDevice(MideaCoordinatorEntity, ClimateEntity):
         """Return device specific state attributes."""
 
         return {
-            "follow_me": self._device.follow_me
+            "follow_me": f"{self._device.follow_me}",
+            "error_code": f"{self._device.error_code}",
         }
 
     async def async_set_follow_me(self, enabled: bool) -> None:


### PR DESCRIPTION
Initially requested in https://github.com/mill1000/midea-msmart/issues/237

Requires msmart-ng 2025.9.1