### PR TITLE
Bump msmart-ng to 2025.9.2

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2025.9.0"
+    "msmart-ng==2025.9.2"
   ],
   "version": "2025.9.0"
 }


### PR DESCRIPTION
# msmart-ng 2025.9.2
## What's Changed
* Add device type check to Frame.validate method by @mill1000 in https://github.com/mill1000/midea-msmart/pull/239
* Update device online/supported logic by @mill1000 in https://github.com/mill1000/midea-msmart/pull/240

# msmart 2025.9.1
## What's Changed
* Remove use of deprecated properties in to_dict by @mill1000 in https://github.com/mill1000/midea-msmart/pull/231
* Validate frame length by @mill1000 in https://github.com/mill1000/midea-msmart/pull/236
* Extract and expose error code from StateResponse by @mill1000 in https://github.com/mill1000/midea-msmart/pull/238