### PR TITLE
Bump msmart-ng to 2026.3.0

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2025.12.0"
+    "msmart-ng==2026.3.0"
   ],
   "version": "2026.2.0"
 }


### PR DESCRIPTION
# msmart-ng 2026.3.0
## What's Changed
* Update to Python 3.14 by @mill1000 in https://github.com/mill1000/midea-msmart/pull/245
* Change return type of target temperature ranges to float by @mill1000 in https://github.com/mill1000/midea-msmart/pull/251
* Add basic support for defrost status by @mill1000 in https://github.com/mill1000/midea-msmart/pull/250
* Update CLI to query capabilities before state with `--capabilities` option by @mill1000 in https://github.com/mill1000/midea-msmart/pull/252
* Add outdoor fan speed from Group5 data response by @mill1000 in https://github.com/mill1000/midea-msmart/pull/253
* Support dumping and overriding device capabilities by @mill1000 in https://github.com/mill1000/midea-msmart/pull/249
* Tidy up device attributes by @mill1000 in https://github.com/mill1000/midea-msmart/pull/254


**Full Changelog**: https://github.com/mill1000/midea-msmart/compare/2025.12.0...2026.3.0