### PR TITLE
Add Midea C3 heat pump (0xC3) support

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -11,12 +11,15 @@ from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 from msmart import __version__ as MSMART_VERSION
 from msmart.base_device import Device
+from msmart.cloud import Cloud, CloudError
 from msmart.const import DeviceType
 from msmart.device import AirConditioner as AC
 from msmart.device import CommercialAirConditioner as CC
+from msmart.device import HeatPump
 from msmart.lan import AuthenticationError
 
 from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_CAPABILITY_OVERRIDES,
+                    CONF_CLOUD_ACCOUNT, CONF_CLOUD_PASSWORD,
                     CONF_DEVICE_TYPE, CONF_ENERGY_DATA_FORMAT,
                     CONF_ENERGY_DATA_SCALE, CONF_ENERGY_SENSOR, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME,
@@ -58,7 +61,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         port=port,
         device_id=int(id)
     )
-    assert isinstance(device, (AC, CC))
+    assert isinstance(device, (AC, CC, HeatPump))
 
     # Configure the connection lifetime
     if (lifetime := config_entry.options.get(CONF_MAX_CONNECTION_LIFETIME)) is not None:
@@ -66,22 +69,35 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             "Setting maximum connection lifetime to %s seconds for device ID %s.", lifetime, device.id)
         device.set_max_connection_lifetime(lifetime)
 
-    # Configure token and k1 as needed
-    token = config_entry.data[CONF_TOKEN]
-    key = config_entry.data[CONF_KEY]
-    if token and key:
+    if isinstance(device, HeatPump):
+        # HeatPump devices use cloud relay for communication
+        account = config_entry.data.get(CONF_CLOUD_ACCOUNT)
+        password = config_entry.data.get(CONF_CLOUD_PASSWORD)
+        if not account or not password:
+            raise ConfigEntryNotReady("HeatPump device requires cloud account credentials.")
+        cloud = Cloud(account=account, password=password)
         try:
-            await device.authenticate(token, key)
-        except AuthenticationError as e:
-            raise ConfigEntryNotReady(
-                "Failed to authenticate with device.") from e
+            await cloud.login()
+        except CloudError as e:
+            raise ConfigEntryNotReady("Failed to login to Midea cloud.") from e
+        device.set_cloud(cloud)
+    else:
+        # Configure token and k1 as needed for AC/CC devices
+        token = config_entry.data[CONF_TOKEN]
+        key = config_entry.data[CONF_KEY]
+        if token and key:
+            try:
+                await device.authenticate(token, key)
+            except AuthenticationError as e:
+                raise ConfigEntryNotReady(
+                    "Failed to authenticate with device.") from e
 
-    # Query device capabilities
-    _LOGGER.info("Querying capabilities for device ID %s.", device.id)
-    await device.get_capabilities()
+        # Query device capabilities (AC/CC only)
+        _LOGGER.info("Querying capabilities for device ID %s.", device.id)
+        await device.get_capabilities()
 
-    # Apply capability overrides if present
-    if (yaml_input := config_entry.options.get(CONF_CAPABILITY_OVERRIDES)):
+    # Apply capability overrides if present (AC/CC only)
+    if not isinstance(device, HeatPump) and (yaml_input := config_entry.options.get(CONF_CAPABILITY_OVERRIDES)):
         try:
             overrides = yaml.safe_load(yaml_input)
             merge = config_entry.options.get(

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -23,6 +23,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from msmart.const import DeviceType
 from msmart.device import AirConditioner as AC
 from msmart.device import CommercialAirConditioner as CC
+from msmart.device import HeatPump
 from msmart.utils import MideaIntEnum
 
 from .const import (CONF_BEEP, CONF_TEMP_STEP, CONF_USE_FAN_ONLY_WORKAROUND,
@@ -64,6 +65,10 @@ async def async_setup_entry(
     elif device.type == DeviceType.COMMERCIAL_AC:
         entities.append(
             MideaClimateCCDevice(hass, coordinator, config_entry.options))
+
+    elif device.type == DeviceType.HEAT_PUMP:
+        entities.append(
+            MideaClimateHeatPumpZone(hass, coordinator, config_entry.options, zone_index=1))
 
     add_entities(entities)
 
@@ -652,3 +657,130 @@ class MideaClimateCCDevice(MideaClimateDevice[CC]):
         self._device.sleep = preset_mode == PRESET_SLEEP
 
         await self._apply()
+
+
+class MideaClimateHeatPumpZone(MideaCoordinatorEntity[HeatPump], ClimateEntity):
+    """Climate entity for a heat pump zone."""
+
+    _attr_translation_key = DOMAIN
+    _enable_turn_on_off_backwards_compatibility = False
+
+    _RUN_MODE_TO_HVAC_MODE: ClassVar[Mapping[HeatPump.RunMode, HVACMode]] = {
+        HeatPump.RunMode.AUTO: HVACMode.AUTO,
+        HeatPump.RunMode.COOL: HVACMode.COOL,
+        HeatPump.RunMode.HEAT: HVACMode.HEAT,
+    }
+
+    _HVAC_MODE_TO_RUN_MODE: ClassVar[Mapping[HVACMode, HeatPump.RunMode]] = {
+        HVACMode.AUTO: HeatPump.RunMode.AUTO,
+        HVACMode.COOL: HeatPump.RunMode.COOL,
+        HVACMode.HEAT: HeatPump.RunMode.HEAT,
+    }
+
+    def __init__(self,
+                 hass: HomeAssistant,
+                 coordinator: MideaDeviceUpdateCoordinator[HeatPump],
+                 options: Mapping[str, Any],
+                 zone_index: int = 1
+                 ) -> None:
+        MideaCoordinatorEntity.__init__(self, coordinator)
+        self.hass = hass
+        self._zone_index = zone_index
+        self._temperature_step = options.get(CONF_TEMP_STEP, 1.0)
+
+        self._supported_features = ClimateEntityFeature.TARGET_TEMPERATURE
+        try:
+            self._supported_features |= ClimateEntityFeature.TURN_OFF
+            self._supported_features |= ClimateEntityFeature.TURN_ON
+        except AttributeError:
+            pass
+
+    @property
+    def device_info(self) -> dict:
+        return {
+            "identifiers": {(DOMAIN, self._device.id)},
+            "name": f"Midea {self._device.type:X} {self._device.id}",
+            "manufacturer": "Midea",
+        }
+
+    @property
+    def has_entity_name(self) -> bool:
+        return True
+
+    @property
+    def name(self) -> str | None:
+        if self._zone_index == 1:
+            return "Zone 1"
+        return f"Zone {self._zone_index}"
+
+    @property
+    def unique_id(self) -> str:
+        return f"{self._device.id}-zone{self._zone_index}"
+
+    @property
+    def supported_features(self) -> int:
+        return self._supported_features
+
+    @property
+    def temperature_unit(self) -> str:
+        return UnitOfTemperature.CELSIUS
+
+    @property
+    def target_temperature_step(self) -> float:
+        return self._temperature_step
+
+    @property
+    def hvac_modes(self) -> list[HVACMode]:
+        return [HVACMode.OFF, HVACMode.AUTO, HVACMode.HEAT, HVACMode.COOL]
+
+    @property
+    def hvac_mode(self) -> HVACMode:
+        zone = self._device.zone1 if self._zone_index == 1 else self._device.zone2
+        if zone is None or not zone.power_state:
+            return HVACMode.OFF
+        return self._RUN_MODE_TO_HVAC_MODE.get(self._device.run_mode, HVACMode.AUTO)
+
+    async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
+        if hvac_mode == HVACMode.OFF:
+            self._device.zone1_power_state = False
+        else:
+            self._device.zone1_power_state = True
+            if run_mode := self._HVAC_MODE_TO_RUN_MODE.get(hvac_mode):
+                self._device.run_mode = run_mode
+        await self.coordinator.apply()
+
+    @property
+    def current_temperature(self) -> float | None:
+        return self._device.water_temperature
+
+    @property
+    def target_temperature(self) -> float | None:
+        return self._device.zone1_target_temperature
+
+    async def async_set_temperature(self, **kwargs) -> None:
+        if (temperature := kwargs.get(ATTR_TEMPERATURE)) is not None:
+            self._device.zone1_target_temperature = int(temperature)
+        await self.coordinator.apply()
+
+        if (mode := kwargs.get(ATTR_HVAC_MODE)) is not None:
+            await self.async_set_hvac_mode(mode)
+
+    @property
+    def min_temp(self) -> float:
+        if self._device.run_mode == HeatPump.RunMode.COOL:
+            return self._device.zone1_min_cool_temperature
+        return self._device.zone1_min_heat_temperature
+
+    @property
+    def max_temp(self) -> float:
+        if self._device.run_mode == HeatPump.RunMode.COOL:
+            return self._device.zone1_max_cool_temperature
+        return self._device.zone1_max_heat_temperature
+
+    async def async_turn_on(self) -> None:
+        self._device.zone1_power_state = True
+        await self.coordinator.apply()
+
+    async def async_turn_off(self) -> None:
+        self._device.zone1_power_state = False
+        await self.coordinator.apply()

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -265,12 +265,29 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         errors = {}
 
         if user_input is not None:
-            # Get device ID from user input
-            id = int(user_input.get(CONF_ID))
+            raw_id = (user_input.get(CONF_ID) or "").strip()
+            device_type_str = (user_input.get(CONF_DEVICE_TYPE) or "").upper()
 
-            # Check if device has already been configured
-            await self.async_set_unique_id(str(id))
-            self._abort_if_unique_id_configured()
+            # Auto-discover device ID for HeatPump when not provided
+            if not raw_id:
+                if device_type_str == f"{DeviceType.HEAT_PUMP:X}":
+                    host = user_input.get(CONF_HOST)
+                    info = await Discover.probe_device_info(host, timeout=5)
+                    if info and info.get("device_id"):
+                        raw_id = str(info["device_id"])
+                        user_input = {**user_input, CONF_ID: raw_id}
+                    else:
+                        errors[CONF_ID] = "device_not_found"
+                else:
+                    errors[CONF_ID] = "device_not_found"
+
+            if not errors:
+                id = int(raw_id)
+
+            if not errors:
+                # Check if device has already been configured
+                await self.async_set_unique_id(str(id))
+                self._abort_if_unique_id_configured()
 
             # Validate the hex format of certain fields
             for field in [CONF_TOKEN, CONF_KEY]:
@@ -298,7 +315,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         data_schema = self.add_suggested_values_to_schema(
             vol.Schema({
-                vol.Required(CONF_ID): cv.string,
+                vol.Optional(CONF_ID): cv.string,
                 vol.Required(CONF_HOST): cv.string,
                 vol.Required(CONF_PORT, default=6444): cv.port,
                 vol.Required(CONF_DEVICE_TYPE): SelectSelector(

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -25,14 +25,17 @@ from homeassistant.helpers.selector import (CountrySelector,
                                             TextSelectorConfig,
                                             TextSelectorType)
 from msmart.base_device import Device
+from msmart.cloud import Cloud, CloudError
 from msmart.const import DeviceType
 from msmart.device import AirConditioner as AC
 from msmart.device import CommercialAirConditioner as CC
-from msmart.discover import CloudError, Discover
+from msmart.device import HeatPump
+from msmart.discover import Discover
 from msmart.lan import AuthenticationError
 
 from .const import (CONF_BEEP, CONF_CAPABILITY_OVERRIDES,
-                    CONF_CLOUD_COUNTRY_CODES, CONF_DEFAULT_CLOUD_COUNTRY,
+                    CONF_CLOUD_ACCOUNT, CONF_CLOUD_COUNTRY_CODES,
+                    CONF_CLOUD_PASSWORD, CONF_DEFAULT_CLOUD_COUNTRY,
                     CONF_DEVICE_TYPE, CONF_ENERGY_DATA_FORMAT,
                     CONF_ENERGY_DATA_SCALE, CONF_ENERGY_SENSOR,
                     CONF_FAN_SPEED_STEP, CONF_KEY,
@@ -289,7 +292,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     errors["base"] = "unsupported_device"
                 else:
                     # Create entry from valid device
-                    return await self._create_entry_from_device(device)
+                    return await self._create_entry_from_device(device, config=user_input)
 
         user_input = user_input or {}
 
@@ -301,13 +304,16 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                 vol.Required(CONF_DEVICE_TYPE): SelectSelector(
                     SelectSelectorConfig(
                         options=[f"{e.value:X}" for e in
-                                 [DeviceType.AIR_CONDITIONER, DeviceType.COMMERCIAL_AC]],
+                                 [DeviceType.AIR_CONDITIONER, DeviceType.COMMERCIAL_AC,
+                                  DeviceType.HEAT_PUMP]],
                         translation_key="device_type",
                         mode=SelectSelectorMode.DROPDOWN,
                     ),
                 ),
                 vol.Optional(CONF_TOKEN): TextSelector(TextSelectorConfig(type=TextSelectorType.TEXT)),
-                vol.Optional(CONF_KEY): cv.string
+                vol.Optional(CONF_KEY): cv.string,
+                vol.Optional(CONF_CLOUD_ACCOUNT): cv.string,
+                vol.Optional(CONF_CLOUD_PASSWORD): TextSelector(TextSelectorConfig(type=TextSelectorType.PASSWORD)),
             }), user_input)
 
         return self.async_show_form(
@@ -386,38 +392,56 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         """Create an httpx AsyncClient in a HA friendly way."""
         return httpx_client.get_async_client(self.hass, *args, **kwargs)
 
-    async def _test_manual_connection(self, config) -> AC | CC | None:
+    async def _test_manual_connection(self, config) -> AC | CC | HeatPump | None:
         DEVICE_TYPES = {
             "AC": DeviceType.AIR_CONDITIONER,
-            "CC": DeviceType.COMMERCIAL_AC
+            "CC": DeviceType.COMMERCIAL_AC,
+            f"{DeviceType.HEAT_PUMP:X}": DeviceType.HEAT_PUMP,
         }
+
+        device_type = DEVICE_TYPES.get(config.get(CONF_DEVICE_TYPE).upper())
+        if device_type is None:
+            return None
 
         # Construct the device
         device = Device.construct(
-            type=DEVICE_TYPES[config.get(CONF_DEVICE_TYPE).upper()],
+            type=device_type,
             ip=config.get(CONF_HOST),
             port=config.get(CONF_PORT),
             device_id=int(config.get(CONF_ID)),
         )
 
         # Ensure device is a supported type
-        assert isinstance(device, (AC, CC))
+        assert isinstance(device, (AC, CC, HeatPump))
 
-        # Authenticate with device as needed
-        token = config.get(CONF_TOKEN)
-        key = config.get(CONF_KEY)
-        if token and key:
-            try:
-                await device.authenticate(token, key)
-            except AuthenticationError:
+        if isinstance(device, HeatPump):
+            # HeatPump requires cloud relay
+            account = config.get(CONF_CLOUD_ACCOUNT)
+            password = config.get(CONF_CLOUD_PASSWORD)
+            if not account or not password:
                 return None
+            cloud = Cloud(account=account, password=password)
+            try:
+                await cloud.login()
+            except CloudError:
+                return None
+            device.set_cloud(cloud)
+        else:
+            # Authenticate with device as needed
+            token = config.get(CONF_TOKEN)
+            key = config.get(CONF_KEY)
+            if token and key:
+                try:
+                    await device.authenticate(token, key)
+                except AuthenticationError:
+                    return None
 
         # Attempt to refresh device state
         await device.refresh()
 
         return device
 
-    async def _create_entry_from_device(self, device) -> ConfigFlowResult:
+    async def _create_entry_from_device(self, device, config=None) -> ConfigFlowResult:
         # Save the device into global data
         self.hass.data.setdefault(DOMAIN, {})
 
@@ -427,9 +451,14 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
             CONF_ID: device.id,
             CONF_HOST: device.ip,
             CONF_PORT: device.port,
-            CONF_TOKEN: device.token,
-            CONF_KEY: device.key,
+            CONF_TOKEN: getattr(device, "token", None),
+            CONF_KEY: getattr(device, "key", None),
         }
+
+        # Store cloud credentials for HeatPump devices
+        if isinstance(device, HeatPump) and config:
+            data[CONF_CLOUD_ACCOUNT] = config.get(CONF_CLOUD_ACCOUNT)
+            data[CONF_CLOUD_PASSWORD] = config.get(CONF_CLOUD_PASSWORD)
 
         # Build default options based on device type
         default_options = _DEFAULT_OPTIONS

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -3,6 +3,7 @@ from typing import TypeVar
 
 from msmart.device import AirConditioner as AC
 from msmart.device import CommercialAirConditioner as CC
+from msmart.device import HeatPump
 
 DOMAIN = "midea_ac"
 UPDATE_INTERVAL = 15
@@ -24,6 +25,8 @@ CONF_CLOUD_COUNTRY_CODES = ["DE", "KR", "US"]
 CONF_DEFAULT_CLOUD_COUNTRY = "US"
 CONF_SWING_ANGLE_RTL = "swing_angle_rtl"
 CONF_DEVICE_TYPE = "device_type"
+CONF_CLOUD_ACCOUNT = "cloud_account"
+CONF_CLOUD_PASSWORD = "cloud_password"
 CONF_CAPABILITY_OVERRIDES = "capability_overrides"
 CONF_MERGE_CAPABILITY_OVERRIDES = "merge_capability_overrides"
 
@@ -41,4 +44,4 @@ class EnergyFormat(StrEnum):
     _ALTERNATE_B = "alternate_b"
 
 
-MideaDevice = TypeVar("MideaDevice", AC, CC)
+MideaDevice = TypeVar("MideaDevice", AC, CC, HeatPump)

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -7,6 +7,7 @@ from msmart.device import HeatPump
 
 DOMAIN = "midea_ac"
 UPDATE_INTERVAL = 15
+UPDATE_INTERVAL_CLOUD = 60  # Longer interval for cloud-relayed devices (e.g. HeatPump)
 
 CONF_KEY = "k1"
 CONF_BEEP = "prompt_tone"

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -7,7 +7,6 @@ from msmart.device import HeatPump
 
 DOMAIN = "midea_ac"
 UPDATE_INTERVAL = 15
-UPDATE_INTERVAL_CLOUD = 60  # Longer interval for cloud-relayed devices (e.g. HeatPump)
 
 CONF_KEY = "k1"
 CONF_BEEP = "prompt_tone"

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
 
-from .const import DOMAIN, UPDATE_INTERVAL, UPDATE_INTERVAL_CLOUD, MideaDevice
+from .const import DOMAIN, UPDATE_INTERVAL, MideaDevice
 from .device_proxy import MideaDeviceProxy
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,13 +20,11 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
     """Device update coordinator for Midea Smart AC."""
 
     def __init__(self, hass: HomeAssistant, device: MideaDevice) -> None:
-        # Use a longer interval for cloud-relayed devices to avoid excessive notifications
-        interval = UPDATE_INTERVAL_CLOUD if getattr(device, "_cloud", None) is not None else UPDATE_INTERVAL
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=datetime.timedelta(seconds=interval),
+            update_interval=datetime.timedelta(seconds=UPDATE_INTERVAL),
             request_refresh_debouncer=Debouncer(
                 hass,
                 _LOGGER,

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -10,7 +10,7 @@ from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
 
-from .const import DOMAIN, UPDATE_INTERVAL, MideaDevice
+from .const import DOMAIN, UPDATE_INTERVAL, UPDATE_INTERVAL_CLOUD, MideaDevice
 from .device_proxy import MideaDeviceProxy
 
 _LOGGER = logging.getLogger(__name__)
@@ -20,11 +20,13 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
     """Device update coordinator for Midea Smart AC."""
 
     def __init__(self, hass: HomeAssistant, device: MideaDevice) -> None:
+        # Use a longer interval for cloud-relayed devices to avoid excessive notifications
+        interval = UPDATE_INTERVAL_CLOUD if getattr(device, "_cloud", None) is not None else UPDATE_INTERVAL
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=datetime.timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=datetime.timedelta(seconds=interval),
             request_refresh_debouncer=Debouncer(
                 hass,
                 _LOGGER,

--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2026.4.1",
+    "msmart-ng @ git+https://github.com/xelhark/midea-msmart@feature/c3_heatpump",
     "pyyaml"
   ],
   "version": "2026.4.0"

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -10,6 +10,7 @@ from homeassistant.const import (PERCENTAGE, UnitOfEnergy, UnitOfPower,
                                  UnitOfTemperature)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
+from msmart.const import DeviceType
 from msmart.utils import MideaIntEnum
 
 from .const import (CONF_ENERGY_DATA_FORMAT, CONF_ENERGY_DATA_SCALE,
@@ -122,6 +123,38 @@ async def async_setup_entry(
             None,
             "outdoor_fan_speed",
         ))
+
+    if device.type == DeviceType.HEAT_PUMP:
+        entities.extend([
+            MideaSensor(
+                coordinator,
+                "water_temperature",
+                SensorDeviceClass.TEMPERATURE,
+                UnitOfTemperature.CELSIUS,
+                "water_temperature",
+            ),
+            MideaSensor(
+                coordinator,
+                "outdoor_temperature",
+                SensorDeviceClass.TEMPERATURE,
+                UnitOfTemperature.CELSIUS,
+                "outdoor_temperature",
+            ),
+            MideaSensor(
+                coordinator,
+                "electric_power",
+                SensorDeviceClass.POWER,
+                UnitOfPower.WATT,
+                "electric_power",
+            ),
+            MideaSensor(
+                coordinator,
+                "thermal_power",
+                SensorDeviceClass.POWER,
+                UnitOfPower.WATT,
+                "thermal_power",
+            ),
+        ])
 
     add_entities(entities)
 

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -26,11 +26,15 @@
           "port": "Port",
           "device_type": "Device Type",
           "token": "Token",
-          "k1": "Key"
+          "k1": "Key",
+          "cloud_account": "Cloud Account",
+          "cloud_password": "Cloud Password"
         },
         "data_description": {
           "token": "Token for V3 devices (hexadecimal)",
-          "k1": "Key for V3 devices (hexadecimal)"
+          "k1": "Key for V3 devices (hexadecimal)",
+          "cloud_account": "MSmartHome account email (required for Heat Pump)",
+          "cloud_password": "MSmartHome account password (required for Heat Pump)"
         }
       },
       "reconfigure": {
@@ -130,6 +134,13 @@
     }
   },
   "selector": {
+    "device_type": {
+      "options": {
+        "AC": "Air Conditioner",
+        "CC": "Commercial AC",
+        "C3": "Heat Pump"
+      }
+    },
     "energy_data_format": {
       "options": {
         "bcd": "BCD",
@@ -310,6 +321,15 @@
       },
       "total_energy_usage": {
         "name": "Total energy"
+      },
+      "water_temperature": {
+        "name": "Water temperature"
+      },
+      "electric_power": {
+        "name": "Electric power"
+      },
+      "thermal_power": {
+        "name": "Thermal power"
       }
     },
     "switch": {

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -21,7 +21,7 @@
       "manual": {
         "description": "Enter information for your device.",
         "data": {
-          "id": "ID",
+          "id": "ID (auto-detected for Heat Pump)",
           "host": "Host",
           "port": "Port",
           "device_type": "Device Type",


### PR DESCRIPTION
## Summary

- Add `HeatPump` (0xC3) device type to config flow: device type selector, cloud credentials (MSmartHome account/password), auto-discovery of device ID via UDP probe
- Add `MideaClimateHeatPumpZone` climate entity: zone1 power, target temperature, HVAC modes (HEAT/COOL/AUTO/OFF)
- Add sensor entities for water temperature, outdoor temperature, electric power, thermal power
- Wire up `SmartHomeCloud` login in `async_setup_entry` for HeatPump devices (cloud relay instead of LAN)
- Skip `get_capabilities()` and capability overrides for HeatPump
- Add translations for all new fields and entities

## Notes

- Depends on: https://github.com/mill1000/midea-msmart/pull/262
- HeatPump device ID is auto-detected via `Discover.probe_device_info()` when left blank in the config form — user only needs host, port, and cloud credentials
- Outdoor temperature and power sensors return unavailable (the relay endpoint for those is async-push only)

## Test plan

- [x] Tested against a real Midea C3 heat pump via Home Assistant
- [x] Config flow completes with auto-discovered device ID
- [x] Climate entity shows correct mode and target temperature
- [x] Integration reloads cleanly after HA restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)