### PR TITLE
Ensure proper cleanup of tests to avoid new "Failed: Lingering timer after test" during `verify_cleanup`

### DIFF
--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -234,3 +234,5 @@ async def test_group5_entity_request_enable(
     await entities[1].async_will_remove_from_hass()
     assert coordinator._group5_entities == 0
     assert device.enable_group5_data_requests == False
+
+    await coordinator.async_shutdown()

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -58,3 +58,5 @@ async def test_energy_sensor_request_enable(
     await sensors[1].async_will_remove_from_hass()
     assert coordinator._energy_sensors == 0
     assert device.enable_energy_usage_requests == False
+
+    await coordinator.async_shutdown()


### PR DESCRIPTION
Shut down the coordinators to ensure all timers are destroyed.