### PR TITLE
Bump msmart-ng to 2026.7.0

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2026.4.1",
+    "msmart-ng==2026.7.0",
     "pyyaml"
   ],
   "version": "2026.4.0"


### PR DESCRIPTION
# msmart-ng 2026.7.0

## Notable changes
* Add support for Fresh Air (ventilation) on AC devices by @NotixOfficial in https://github.com/mill1000/midea-msmart/pull/268
* Support additional iECO "modes" by @mill1000 in https://github.com/mill1000/midea-msmart/pull/272
* Replace "Jet Cool" with "Flash" by @mill1000 in https://github.com/mill1000/midea-msmart/pull/273
* Update fan speed capability decoding based on latest plugin by @mill1000 in https://github.com/mill1000/midea-msmart/pull/270
* Update mode capability decoding based on latest plugin by @mill1000 in https://github.com/mill1000/midea-msmart/pull/269