### PR TITLE
Update iECO preset string to "iECO / ECOMaster"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ _However_, for newer "V3" devices, the Midea Cloud is used to acquire a token & 
   * Start and monitor self-cleaning
   * Rate selection (Gear mode)
   * "Breeze" modes (e.g., breeze away, breeze mild, breezeless)
-  * iECO
+  * iECO (ECOMaster/ECO+)
   * Auxiliary heating mode
   * Flash/jet cool
   * Cascade

--- a/custom_components/midea_ac/translations/bg.json
+++ b/custom_components/midea_ac/translations/bg.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/ca.json
+++ b/custom_components/midea_ac/translations/ca.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/cs.json
+++ b/custom_components/midea_ac/translations/cs.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/de.json
+++ b/custom_components/midea_ac/translations/de.json
@@ -167,7 +167,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO",
+              "ieco": "iECO / ECOMaster",
               "silent": "Leise"
             }
           },

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -173,7 +173,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO",
+              "ieco": "iECO / ECOMaster",
               "silent": "Silent"
             }
           },

--- a/custom_components/midea_ac/translations/es.json
+++ b/custom_components/midea_ac/translations/es.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/eu.json
+++ b/custom_components/midea_ac/translations/eu.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/fr.json
+++ b/custom_components/midea_ac/translations/fr.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/hr.json
+++ b/custom_components/midea_ac/translations/hr.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/hu.json
+++ b/custom_components/midea_ac/translations/hu.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/it.json
+++ b/custom_components/midea_ac/translations/it.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/ko.json
+++ b/custom_components/midea_ac/translations/ko.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/mk.json
+++ b/custom_components/midea_ac/translations/mk.json
@@ -167,7 +167,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO",
+              "ieco": "iECO / ECOMaster",
               "silent": "Тивок"
             }
           },

--- a/custom_components/midea_ac/translations/nb.json
+++ b/custom_components/midea_ac/translations/nb.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/nl.json
+++ b/custom_components/midea_ac/translations/nl.json
@@ -167,7 +167,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO",
+              "ieco": "iECO / ECOMaster",
               "silent": "Stil"
             }
           },

--- a/custom_components/midea_ac/translations/pl.json
+++ b/custom_components/midea_ac/translations/pl.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/pt.json
+++ b/custom_components/midea_ac/translations/pt.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/ro.json
+++ b/custom_components/midea_ac/translations/ro.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/ru.json
+++ b/custom_components/midea_ac/translations/ru.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/sk.json
+++ b/custom_components/midea_ac/translations/sk.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/sl.json
+++ b/custom_components/midea_ac/translations/sl.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/tr.json
+++ b/custom_components/midea_ac/translations/tr.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/uk.json
+++ b/custom_components/midea_ac/translations/uk.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/zh-Hans.json
+++ b/custom_components/midea_ac/translations/zh-Hans.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {

--- a/custom_components/midea_ac/translations/zh-Hant.json
+++ b/custom_components/midea_ac/translations/zh-Hant.json
@@ -159,7 +159,7 @@
           },
           "preset_mode": {
             "state": {
-              "ieco": "iECO"
+              "ieco": "iECO / ECOMaster"
             }
           },
           "swing_mode": {


### PR DESCRIPTION
ECOMaster, ECO+ and iECO are all controlled by the same property in msmart-ng. 