### PR TITLE
Start from cached capabilities when the device is offline at setup

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -1,6 +1,7 @@
 """Integration for Midea Smart AC."""
 from __future__ import annotations
 
+import enum
 import logging
 
 import yaml
@@ -16,7 +17,8 @@ from msmart.device import AirConditioner as AC
 from msmart.device import CommercialAirConditioner as CC
 from msmart.lan import AuthenticationError
 
-from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_CAPABILITY_OVERRIDES,
+from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_CACHED_CAPS,
+                    CONF_CAPABILITY_OVERRIDES,
                     CONF_DEVICE_TYPE, CONF_ENERGY_DATA_FORMAT,
                     CONF_ENERGY_DATA_SCALE, CONF_ENERGY_SENSOR, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME,
@@ -36,6 +38,17 @@ _PLATFORMS = [
     Platform.SENSOR,
     Platform.SWITCH
 ]
+
+
+def _caps_to_names(obj):
+    """Recursively convert enum values to their names so caps are JSON-serializable."""
+    if isinstance(obj, enum.Enum):
+        return obj.name
+    if isinstance(obj, dict):
+        return {k: _caps_to_names(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple, set)):
+        return [_caps_to_names(v) for v in obj]
+    return obj
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -67,6 +80,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             "Setting maximum connection lifetime to %s seconds for device ID %s.", lifetime, device.id)
         device.set_max_connection_lifetime(lifetime)
 
+    # Capabilities cached from a previous successful setup. Lets the entry start
+    # while the device is offline instead of raising ConfigEntryNotReady.
+    cached_caps = config_entry.data.get(CONF_CACHED_CAPS)
+    reachable = True
+
     # Configure token and k1 as needed
     token = config_entry.data[CONF_TOKEN]
     key = config_entry.data[CONF_KEY]
@@ -74,12 +92,43 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         try:
             await device.authenticate(token, key)
         except AuthenticationError as e:
-            raise ConfigEntryNotReady(
-                "Failed to authenticate with device.") from e
+            # Without cached capabilities we cannot build entities, so keep HA's
+            # standard "retry setup" behavior.
+            if not cached_caps:
+                raise ConfigEntryNotReady(
+                    "Failed to authenticate with device.") from e
+            _LOGGER.warning(
+                "Could not authenticate with device ID %s, starting from cached capabilities: %s",
+                device.id, e)
+            reachable = False
 
-    # Query device capabilities
-    _LOGGER.info("Querying capabilities for device ID %s.", device.id)
-    await device.get_capabilities()
+    # Query device capabilities (and cache them for offline starts)
+    if reachable:
+        try:
+            _LOGGER.info("Querying capabilities for device ID %s.", device.id)
+            await device.get_capabilities()
+
+            # Cache capabilities so the entry can start while the device is offline.
+            # Only write when changed: async_update_entry notifies the update
+            # listener registered below and could otherwise cause a reload loop.
+            caps = _caps_to_names(device.capabilities_dict())
+            if caps != cached_caps:
+                hass.config_entries.async_update_entry(
+                    config_entry,
+                    data={**config_entry.data, CONF_CACHED_CAPS: caps})
+        except Exception as e:  # noqa: BLE001 - fall back to cache on any query failure
+            if not cached_caps:
+                raise ConfigEntryNotReady(
+                    f"Failed to query device capabilities: {e}") from e
+            _LOGGER.warning(
+                "Could not query capabilities for device ID %s, starting from cache: %s",
+                device.id, e)
+            reachable = False
+
+    # Build entities from cached capabilities when the device is unreachable.
+    # Full replace (merge=False) mirrors what a successful get_capabilities() sets.
+    if not reachable:
+        device.override_capabilities(cached_caps, merge=False)
 
     # Apply capability overrides if present
     if (yaml_input := config_entry.options.get(CONF_CAPABILITY_OVERRIDES)):
@@ -96,7 +145,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
 
     # Create device coordinator and fetch data
     coordinator = MideaDeviceUpdateCoordinator(hass, device)  # type: ignore
-    await coordinator.async_config_entry_first_refresh()
+    if reachable:
+        await coordinator.async_config_entry_first_refresh()
+    else:
+        # No ConfigEntryNotReady -> no error banner. Entities start 'unavailable'
+        # (device.online is False); the coordinator reconnects in the background.
+        await coordinator.async_refresh()
 
     # Store coordinator in global data
     hass.data[DOMAIN][config_entry.entry_id] = coordinator

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -17,8 +17,8 @@ from msmart.device import AirConditioner as AC
 from msmart.device import CommercialAirConditioner as CC
 from msmart.lan import AuthenticationError
 
-from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_CACHED_CAPS,
-                    CONF_CAPABILITY_OVERRIDES,
+from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_ALLOW_OFFLINE_STARTUP,
+                    CONF_CACHED_CAPS, CONF_CAPABILITY_OVERRIDES,
                     CONF_DEVICE_TYPE, CONF_ENERGY_DATA_FORMAT,
                     CONF_ENERGY_DATA_SCALE, CONF_ENERGY_SENSOR, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME,
@@ -80,9 +80,11 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             "Setting maximum connection lifetime to %s seconds for device ID %s.", lifetime, device.id)
         device.set_max_connection_lifetime(lifetime)
 
-    # Capabilities cached from a previous successful setup. Lets the entry start
-    # while the device is offline instead of raising ConfigEntryNotReady.
+    # Capabilities cached from a previous successful setup. When "Allow offline
+    # startup" is enabled, they let the entry start while the device is offline
+    # instead of raising ConfigEntryNotReady.
     cached_caps = config_entry.data.get(CONF_CACHED_CAPS)
+    allow_offline = config_entry.options.get(CONF_ALLOW_OFFLINE_STARTUP, False)
     reachable = True
 
     # Configure token and k1 as needed
@@ -92,9 +94,9 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
         try:
             await device.authenticate(token, key)
         except AuthenticationError as e:
-            # Without cached capabilities we cannot build entities, so keep HA's
-            # standard "retry setup" behavior.
-            if not cached_caps:
+            # Keep HA's standard "retry setup" behavior unless offline startup is
+            # allowed and we have cached capabilities to build entities from.
+            if not (allow_offline and cached_caps):
                 raise ConfigEntryNotReady(
                     "Failed to authenticate with device.") from e
             _LOGGER.warning(
@@ -117,7 +119,7 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                     config_entry,
                     data={**config_entry.data, CONF_CACHED_CAPS: caps})
         except Exception as e:  # noqa: BLE001 - fall back to cache on any query failure
-            if not cached_caps:
+            if not (allow_offline and cached_caps):
                 raise ConfigEntryNotReady(
                     f"Failed to query device capabilities: {e}") from e
             _LOGGER.warning(

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -143,8 +143,10 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
             _LOGGER.error(
                 "Failed to apply capability overrides for device ID %s: %s", device.id, e)
 
-    # Create device coordinator and fetch data
-    coordinator = MideaDeviceUpdateCoordinator(hass, device)  # type: ignore
+    # Create device coordinator and fetch data. Pass token/key so the
+    # coordinator can (re)authenticate a V3 device that started from cache
+    # while offline and whose credentials were never stored.
+    coordinator = MideaDeviceUpdateCoordinator(hass, device, token, key)  # type: ignore
     if reachable:
         await coordinator.async_config_entry_first_refresh()
     else:

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -31,7 +31,8 @@ from msmart.device import CommercialAirConditioner as CC
 from msmart.discover import CloudError, Discover
 from msmart.lan import AuthenticationError
 
-from .const import (CONF_BEEP, CONF_CAPABILITY_OVERRIDES,
+from .const import (CONF_ALLOW_OFFLINE_STARTUP, CONF_BEEP,
+                    CONF_CAPABILITY_OVERRIDES,
                     CONF_CLOUD_COUNTRY_CODES, CONF_DEFAULT_CLOUD_COUNTRY,
                     CONF_DEVICE_TYPE, CONF_ENERGY_DATA_FORMAT,
                     CONF_ENERGY_DATA_SCALE, CONF_ENERGY_SENSOR,
@@ -49,7 +50,8 @@ _DEFAULT_OPTIONS = {
     CONF_MAX_CONNECTION_LIFETIME: None,
     CONF_SWING_ANGLE_RTL: False,
     CONF_CAPABILITY_OVERRIDES: "",
-    CONF_MERGE_CAPABILITY_OVERRIDES: True
+    CONF_MERGE_CAPABILITY_OVERRIDES: True,
+    CONF_ALLOW_OFFLINE_STARTUP: False
 }
 
 _DEFAULT_AC_OPTIONS = {
@@ -471,6 +473,7 @@ class MideaOptionsFlow(OptionsFlow):
                 )
             ),
             vol.Optional(CONF_MERGE_CAPABILITY_OVERRIDES): cv.boolean,
+            vol.Optional(CONF_ALLOW_OFFLINE_STARTUP): cv.boolean,
         }
     )
 

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -26,6 +26,7 @@ CONF_SWING_ANGLE_RTL = "swing_angle_rtl"
 CONF_DEVICE_TYPE = "device_type"
 CONF_CAPABILITY_OVERRIDES = "capability_overrides"
 CONF_MERGE_CAPABILITY_OVERRIDES = "merge_capability_overrides"
+CONF_CACHED_CAPS = "cached_capabilities"
 
 PRESET_IECO = "ieco"
 PRESET_SILENT = "silent"

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -27,6 +27,7 @@ CONF_DEVICE_TYPE = "device_type"
 CONF_CAPABILITY_OVERRIDES = "capability_overrides"
 CONF_MERGE_CAPABILITY_OVERRIDES = "merge_capability_overrides"
 CONF_CACHED_CAPS = "cached_capabilities"
+CONF_ALLOW_OFFLINE_STARTUP = "allow_offline_startup"
 
 PRESET_IECO = "ieco"
 PRESET_SILENT = "silent"

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -9,6 +9,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
 from homeassistant.helpers.update_coordinator import (CoordinatorEntity,
                                                       DataUpdateCoordinator)
+from msmart.lan import AuthenticationError
 
 from .const import DOMAIN, UPDATE_INTERVAL, MideaDevice
 from .device_proxy import MideaDeviceProxy
@@ -19,7 +20,8 @@ _LOGGER = logging.getLogger(__name__)
 class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
     """Device update coordinator for Midea Smart AC."""
 
-    def __init__(self, hass: HomeAssistant, device: MideaDevice) -> None:
+    def __init__(self, hass: HomeAssistant, device: MideaDevice,
+                 token: str | None = None, key: str | None = None) -> None:
         super().__init__(
             hass,
             _LOGGER,
@@ -35,12 +37,25 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
 
         self._lock = Lock()
         self._proxy: MideaDeviceProxy[MideaDevice] = MideaDeviceProxy(device)
+        self._token = token
+        self._key = key
         self._energy_sensors = 0
         self._group5_entities = 0
 
     async def _async_update_data(self) -> None:
         """Update the device data."""
         async with self._lock:
+            # A V3 device that started from cached capabilities while offline
+            # never stored its credentials, so msmart cannot re-authenticate on
+            # its own. (Re)authenticate here so polling recovers once the device
+            # is reachable again. Skipped once authenticated (token is set).
+            if self._token and self._key and self._proxy.token is None:
+                try:
+                    await self._proxy.authenticate(self._token, self._key)
+                except AuthenticationError as e:
+                    _LOGGER.debug(
+                        "Device still unreachable, will retry: %s", e)
+                    return
             await self._proxy.refresh()
 
     async def apply(self) -> None:

--- a/custom_components/midea_ac/translations/de.json
+++ b/custom_components/midea_ac/translations/de.json
@@ -78,12 +78,14 @@
           "temp_step": "Temperaturschritte",
           "fan_speed_step": "Lüftergeschwindigkeitsschritte",
           "max_connection_lifetime": "Maximale Verbindungsdauer",
-          "swing_angle_rtl": "Horizontalen Schwenkwinkel umkehren"
+          "swing_angle_rtl": "Horizontalen Schwenkwinkel umkehren",
+          "allow_offline_startup": "Offline-Start erlauben"
         },
         "data_description": {
           "temp_step": "Schrittgröße für Temperatureinstellung",
           "fan_speed_step": "Schrittgröße für Lüftergeschwindigkeit",
-          "max_connection_lifetime": "Maximale Zeit in Sekunden, die eine Verbindung verwendet wird (mindestens 15 Sekunden)"
+          "max_connection_lifetime": "Maximale Zeit in Sekunden, die eine Verbindung verwendet wird (mindestens 15 Sekunden)",
+          "allow_offline_startup": "Beim Start aus zwischengespeicherten Fähigkeiten laden, wenn das Gerät offline ist, statt einen Einrichtungsfehler anzuzeigen. Entitäten bleiben nicht verfügbar, bis das Gerät wieder verbunden ist."
         },
         "sections": {
           "energy_sensor": {

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -80,14 +80,16 @@
           "max_connection_lifetime": "Maximum Connection Lifetime",
           "swing_angle_rtl": "Reverse Horizontal Swing Angle",
           "capability_overrides": "Capability Overrides",
-          "merge_capability_overrides": "Merge Overrides"
+          "merge_capability_overrides": "Merge Overrides",
+          "allow_offline_startup": "Allow offline startup"
         },
         "data_description": {
           "temp_step": "Step size for temperature set point",
           "fan_speed_step": "Step size for custom fan speeds",
           "max_connection_lifetime": "Maximum time in seconds a connection will be used (15 second minimum)",
           "capability_overrides": "Device capability overrides in YAML format",
-          "merge_capability_overrides": "Merge overrides with existing device capabilities"
+          "merge_capability_overrides": "Merge overrides with existing device capabilities",
+          "allow_offline_startup": "Start from previously cached capabilities when the device is offline, instead of showing a setup error. Entities remain unavailable until the device reconnects."
         },
         "sections": {
           "energy_sensor": {


### PR DESCRIPTION
### Summary

Add an opt-in **"Allow offline startup"** option so a device that is intentionally powered off (e.g. a seasonal/portable PortaSplit) no longer surfaces the *"Failed to authenticate with device."* needs-attention banner on an HA restart. When enabled, the entities start `unavailable` and reconnect in the background — the normal "device offline" UX. The option defaults to **off**, so existing installs keep the current `ConfigEntryNotReady` behavior unchanged.

Fixes #438.

### Problem

`async_setup_entry` raises `ConfigEntryNotReady` whenever the device is unreachable during setup (in `authenticate()`, `get_capabilities()`, or the coordinator's first refresh). A disconnect *after* setup is already handled via `device.online`; the banner only appears when setup re-runs while the device is off, because capabilities are queried live and there is nothing to build entities from.

### Approach

- **New option `allow_offline_startup`** (boolean, default off) in the options flow. When off, setup behaves exactly as before. All of the behavior below is gated on it.
- **Cache capabilities** in `config_entry.data` (`cached_capabilities`) on the first successful `get_capabilities()` — done unconditionally (cheap, and makes the option work immediately once enabled). Enum values are converted to their names so the cache is JSON-serializable; written only when changed to avoid triggering the update-listener reload loop.
- **Start from cache when offline** (option enabled): if the device is unreachable at a later (re)setup and a cache exists, log a warning, rebuild capabilities via `override_capabilities(cached, merge=False)`, and use `coordinator.async_refresh()` (which does not raise) instead of `async_config_entry_first_refresh()`. Entities start `unavailable` because `device.online` is False.
- **Auto-reconnect for V3 devices:** when the entry starts from cache while offline, `authenticate()` failed before msmart stored the token/key on the LAN connection, so the coordinator's `refresh()` (which lazily calls `authenticate()` with no credentials) could never re-establish the session — entities would stay unavailable until a manual reload. The coordinator now receives the token/key and re-authenticates in `_async_update_data` while the device has no stored credentials, so polling recovers automatically once the device is reachable again. The branch is skipped once authenticated (`device.token` is set), leaving the online path unchanged.
- A cold start with **no** cache still raises `ConfigEntryNotReady` — entities cannot be built without capabilities.

### Behavior (with the option enabled)

| Scenario | Before | After |
|---|---|---|
| Online setup | entry loaded | entry loaded; caps cached once |
| Offline (re)setup, cache present | `setup_retry` + banner | entry `loaded`, entities `unavailable` |
| Device returns after offline start | (n/a — banner/retry) | entities auto-recover on next poll, no reload |
| Offline setup, no cache | `setup_retry` + banner | unchanged (`ConfigEntryNotReady`) |
| Option disabled (default) | — | unchanged (`ConfigEntryNotReady`) |

### Testing

Verified end-to-end on a live HA OS instance (core-2026.6.4, msmart-ng 2026.7.0) with a real V3 PortaSplit, option enabled:

1. Device online + HA restart → entry `loaded`; `config_entry.data.cached_capabilities` written once, with enum names (`COOL`, `FAN_ONLY`, `CUSTOM_FAN_SPEED`, …) — JSON-serializable, matching the live device caps.
2. Device powered off + entry reload → entry stays `loaded`, `climate.*` and sensors `unavailable`, **no banner**, log shows
   `Could not authenticate with device ID …, starting from cached capabilities: Connect failed.`
3. Device powered back on (no reload) → the coordinator re-authenticates on the next poll and entities return to `available` on their own within one update interval (confirmed via the logbook `unavailable → off` transition with no intervening setup).
4. No-cache cold start with device off → still `ConfigEntryNotReady` (correct fallback).

Also verified against `msmart-ng==2026.7.0` that `capabilities_dict()` → name conversion → `override_capabilities(..., merge=False)` round-trips cleanly (the raw enum dict is rejected by `override_capabilities`, which is why the name conversion is needed), and that a failed `authenticate()` leaves `device.token`/`device.key` unset (the reason the coordinator must re-authenticate).
