### PR TITLE
Estimate climate entity's hvac_action based on temperature and setpoint 

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -293,45 +293,32 @@ class MideaClimateDevice(MideaCoordinatorEntity[MideaDevice], ClimateEntity, Gen
         return self._OPERATIONAL_MODE_TO_HVAC_MODE.get(self._device.operational_mode, HVACMode.OFF)
 
     @property
-    def hvac_action(self) -> HVACAction | None:
-        """Return the current running hvac action, used to select the state icon."""
-        mode = self.hvac_mode
+    def hvac_action(self) -> HVACAction:
+        """Return the current HVAC action."""
 
-        if mode == HVACMode.OFF:
-            return HVACAction.OFF
-        if mode == HVACMode.FAN_ONLY:
-            return HVACAction.FAN
-        if mode == HVACMode.DRY:
-            return HVACAction.DRYING
-        if mode == HVACMode.COOL:
-            return self._temperature_based_hvac_action(HVACAction.COOLING, None)
-        if mode == HVACMode.HEAT:
-            return self._temperature_based_hvac_action(None, HVACAction.HEATING)
-        if mode == HVACMode.AUTO:
-            return self._temperature_based_hvac_action(HVACAction.COOLING, HVACAction.HEATING)
+        # For basic modes return the matching action
+        _HVAC_MODE_TO_HVAC_ACTION = {
+            HVACMode.OFF: HVACAction.OFF,
+            HVACMode.FAN_ONLY: HVACAction.FAN,
+            HVACMode.DRY: HVACAction.DRYING,
+        }
+        if (action := _HVAC_MODE_TO_HVAC_ACTION.get(self.hvac_mode)) != None:
+            return action
 
-        return None
+        #  The device doesn't report actual activity, so we'll estimate the action based on sensors and set points
+        current = self.current_temperature
+        target = self.target_temperature
 
-    def _temperature_based_hvac_action(
-        self, cooling: HVACAction | None, heating: HVACAction | None
-    ) -> HVACAction:
-        """Derive the hvac action from current vs. target temperature.
-
-        The device doesn't report the actual compressor state, so this is a
-        best guess. ``cooling`` is returned when the room is warmer than
-        target, ``heating`` when cooler. If the relevant action is ``None``
-        for that direction (single-direction modes), ``IDLE`` is returned
-        instead.
-        """
-        current = self._device.indoor_temperature
-        target = self._device.target_temperature
-
-        if current is None or target is None or current == target:
+        if current is None or target is None:
             return HVACAction.IDLE
-        if current > target:
-            return cooling if cooling is not None else HVACAction.IDLE
 
-        return heating if heating is not None else HVACAction.IDLE
+        if self.hvac_mode in [HVACMode.COOL, HVACMode.AUTO] and current > target:
+            return HVACAction.COOLING
+
+        if self.hvac_mode in [HVACMode.HEAT, HVACMode.AUTO] and current < target:
+            return HVACAction.HEATING
+
+        return HVACAction.IDLE
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -304,31 +304,34 @@ class MideaClimateDevice(MideaCoordinatorEntity[MideaDevice], ClimateEntity, Gen
         if mode == HVACMode.DRY:
             return HVACAction.DRYING
         if mode == HVACMode.COOL:
-            return HVACAction.COOLING
+            return self._temperature_based_hvac_action(HVACAction.COOLING, None)
         if mode == HVACMode.HEAT:
-            return HVACAction.HEATING
+            return self._temperature_based_hvac_action(None, HVACAction.HEATING)
         if mode == HVACMode.AUTO:
-            return self._auto_hvac_action()
+            return self._temperature_based_hvac_action(HVACAction.COOLING, HVACAction.HEATING)
 
         return None
 
-    def _auto_hvac_action(self) -> HVACAction:
-        """Estimate the hvac action while in auto mode from the temperature delta.
+    def _temperature_based_hvac_action(
+        self, cooling: HVACAction | None, heating: HVACAction | None
+    ) -> HVACAction:
+        """Derive the hvac action from current vs. target temperature.
 
         The device doesn't report the actual compressor state, so this is a
-        best guess based on current vs. target temperature.
+        best guess. ``cooling`` is returned when the room is warmer than
+        target, ``heating`` when cooler. If the relevant action is ``None``
+        for that direction (single-direction modes), ``IDLE`` is returned
+        instead.
         """
         current = self._device.indoor_temperature
         target = self._device.target_temperature
 
-        if current is None or target is None:
+        if current is None or target is None or current == target:
             return HVACAction.IDLE
         if current > target:
-            return HVACAction.COOLING
-        if current < target:
-            return HVACAction.HEATING
+            return cooling if cooling is not None else HVACAction.IDLE
 
-        return HVACAction.IDLE
+        return heating if heating is not None else HVACAction.IDLE
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -12,7 +12,7 @@ from homeassistant.components.climate.const import (ATTR_HVAC_MODE,
                                                     PRESET_ECO, PRESET_NONE,
                                                     PRESET_SLEEP,
                                                     ClimateEntityFeature,
-                                                    HVACMode)
+                                                    HVACAction, HVACMode)
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (ATTR_TEMPERATURE, CONF_ENABLED,
                                  UnitOfTemperature)
@@ -292,6 +292,44 @@ class MideaClimateDevice(MideaCoordinatorEntity[MideaDevice], ClimateEntity, Gen
 
         return self._OPERATIONAL_MODE_TO_HVAC_MODE.get(self._device.operational_mode, HVACMode.OFF)
 
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current running hvac action, used to select the state icon."""
+        mode = self.hvac_mode
+
+        if mode == HVACMode.OFF:
+            return HVACAction.OFF
+        if mode == HVACMode.FAN_ONLY:
+            return HVACAction.FAN
+        if mode == HVACMode.DRY:
+            return HVACAction.DRYING
+        if mode == HVACMode.COOL:
+            return HVACAction.COOLING
+        if mode == HVACMode.HEAT:
+            return HVACAction.HEATING
+        if mode == HVACMode.AUTO:
+            return self._auto_hvac_action()
+
+        return None
+
+    def _auto_hvac_action(self) -> HVACAction:
+        """Estimate the hvac action while in auto mode from the temperature delta.
+
+        The device doesn't report the actual compressor state, so this is a
+        best guess based on current vs. target temperature.
+        """
+        current = self._device.indoor_temperature
+        target = self._device.target_temperature
+
+        if current is None or target is None:
+            return HVACAction.IDLE
+        if current > target:
+            return HVACAction.COOLING
+        if current < target:
+            return HVACAction.HEATING
+
+        return HVACAction.IDLE
+
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""
         if hvac_mode == HVACMode.OFF:
@@ -491,6 +529,16 @@ class MideaClimateACDevice(MideaClimateDevice[AC]):
             mode = AC.OperationalMode.DRY
 
         return self._OPERATIONAL_MODE_TO_HVAC_MODE.get(mode, HVACMode.OFF)
+
+    @property
+    def hvac_action(self) -> HVACAction | None:
+        """Return the current running hvac action, used to select the state icon."""
+        action = super().hvac_action
+
+        if action == HVACAction.HEATING and self._device.defrost_active:
+            return HVACAction.DEFROSTING
+
+        return action
 
     async def async_set_hvac_mode(self, hvac_mode: HVACMode) -> None:
         """Set the HVAC mode."""

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -242,16 +242,28 @@ async def test_preset_modes(
     ("power_state", "operational_mode", "indoor_temperature",
      "target_temperature", "expected_action"),
     [
+        # Off
         (False, AC.OperationalMode.COOL, 26, 24, HVACAction.OFF),
-        (True, AC.OperationalMode.COOL, 26, 24, HVACAction.COOLING),
-        (True, AC.OperationalMode.COOL, 22, 24, HVACAction.IDLE),
-        (True, AC.OperationalMode.COOL, 24, 24, HVACAction.IDLE),
-        (True, AC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
-        (True, AC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
-        (True, AC.OperationalMode.HEAT, 24, 24, HVACAction.IDLE),
+        # Basic modes
         (True, AC.OperationalMode.DRY, None, 24, HVACAction.DRYING),
         (True, AC.OperationalMode.SMART_DRY, None, 24, HVACAction.DRYING),
         (True, AC.OperationalMode.FAN_ONLY, None, 24, HVACAction.FAN),
+        # Cool
+        (True, AC.OperationalMode.COOL, 26, 24, HVACAction.COOLING),
+        (True, AC.OperationalMode.COOL, 24, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.COOL, 22, 24, HVACAction.IDLE),
+        # Heat
+        (True, AC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
+        (True, AC.OperationalMode.HEAT, 24, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
+        # Auto
+        (True, AC.OperationalMode.AUTO, 22, 24, HVACAction.HEATING),
+        (True, AC.OperationalMode.AUTO, 24, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.AUTO, 26, 24, HVACAction.COOLING),
+        # No sensor input
+        (True, AC.OperationalMode.HEAT, None, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.COOL, None, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.AUTO, None, 24, HVACAction.IDLE),
     ],
 )
 async def test_ac_hvac_action(
@@ -267,38 +279,6 @@ async def test_ac_hvac_action(
     mock_device = AC("0.0.0.0", 0, 0)
     mock_device._power_state = power_state
     mock_device._operational_mode = operational_mode
-    mock_device._indoor_temperature = indoor_temperature
-    mock_device._target_temperature = target_temperature
-
-    mock_coordinator = MagicMock()
-    mock_coordinator.apply = AsyncMock()
-    mock_coordinator.device = mock_device
-
-    climate_device = MideaClimateACDevice(hass, mock_coordinator, {})
-
-    assert climate_device.hvac_action == expected_action
-
-
-@pytest.mark.parametrize(
-    ("indoor_temperature", "target_temperature", "expected_action"),
-    [
-        (None, 24, HVACAction.IDLE),
-        (26, 24, HVACAction.COOLING),
-        (22, 24, HVACAction.HEATING),
-        (24, 24, HVACAction.IDLE),
-    ],
-)
-async def test_ac_hvac_action_auto_mode(
-    hass: HomeAssistant,
-    indoor_temperature: float | None,
-    target_temperature: float,
-    expected_action: HVACAction,
-):
-    """Test hvac_action is estimated from the temperature delta in auto mode."""
-
-    mock_device = AC("0.0.0.0", 0, 0)
-    mock_device._power_state = True
-    mock_device._operational_mode = AC.OperationalMode.AUTO
     mock_device._indoor_temperature = indoor_temperature
     mock_device._target_temperature = target_temperature
 
@@ -336,13 +316,27 @@ async def test_ac_hvac_action_defrosting(
     ("power_state", "operational_mode", "indoor_temperature",
      "target_temperature", "expected_action"),
     [
+        # Off
         (False, CC.OperationalMode.COOL, 26, 24, HVACAction.OFF),
-        (True, CC.OperationalMode.COOL, 26, 24, HVACAction.COOLING),
-        (True, CC.OperationalMode.COOL, 22, 24, HVACAction.IDLE),
-        (True, CC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
-        (True, CC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
+        # Basic modes
         (True, CC.OperationalMode.DRY, None, 24, HVACAction.DRYING),
         (True, CC.OperationalMode.FAN, None, 24, HVACAction.FAN),
+        # Cool
+        (True, CC.OperationalMode.COOL, 26, 24, HVACAction.COOLING),
+        (True, CC.OperationalMode.COOL, 24, 24, HVACAction.IDLE),
+        (True, CC.OperationalMode.COOL, 22, 24, HVACAction.IDLE),
+        # Heat
+        (True, CC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
+        (True, CC.OperationalMode.HEAT, 24, 24, HVACAction.IDLE),
+        (True, CC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
+        # Auto
+        (True, CC.OperationalMode.AUTO, 22, 24, HVACAction.HEATING),
+        (True, CC.OperationalMode.AUTO, 24, 24, HVACAction.IDLE),
+        (True, CC.OperationalMode.AUTO, 26, 24, HVACAction.COOLING),
+        # No sensor input
+        (True, CC.OperationalMode.HEAT, None, 24, HVACAction.IDLE),
+        (True, CC.OperationalMode.COOL, None, 24, HVACAction.IDLE),
+        (True, CC.OperationalMode.AUTO, None, 24, HVACAction.IDLE),
     ],
 )
 async def test_cc_hvac_action(

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from homeassistant.components.climate.const import (PRESET_ECO, PRESET_SLEEP,
                                                     ClimateEntityFeature,
-                                                    HVACMode)
+                                                    HVACAction, HVACMode)
 from homeassistant.core import HomeAssistant
 from msmart.device import AirConditioner as AC
 from msmart.device import CommercialAirConditioner as CC
@@ -236,3 +236,117 @@ async def test_preset_modes(
     # Assert configured modes are present
     for k, _ in config_modes.items():
         assert k in climate_device.preset_modes
+
+
+@pytest.mark.parametrize(
+    ("power_state", "operational_mode", "expected_action"),
+    [
+        (False, AC.OperationalMode.COOL, HVACAction.OFF),
+        (True, AC.OperationalMode.COOL, HVACAction.COOLING),
+        (True, AC.OperationalMode.HEAT, HVACAction.HEATING),
+        (True, AC.OperationalMode.DRY, HVACAction.DRYING),
+        (True, AC.OperationalMode.SMART_DRY, HVACAction.DRYING),
+        (True, AC.OperationalMode.FAN_ONLY, HVACAction.FAN),
+    ],
+)
+async def test_ac_hvac_action(
+    hass: HomeAssistant,
+    power_state: bool,
+    operational_mode: AC.OperationalMode,
+    expected_action: HVACAction,
+):
+    """Test hvac_action reflects the mode for the AC device."""
+
+    mock_device = AC("0.0.0.0", 0, 0)
+    mock_device._power_state = power_state
+    mock_device._operational_mode = operational_mode
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.apply = AsyncMock()
+    mock_coordinator.device = mock_device
+
+    climate_device = MideaClimateACDevice(hass, mock_coordinator, {})
+
+    assert climate_device.hvac_action == expected_action
+
+
+@pytest.mark.parametrize(
+    ("indoor_temperature", "target_temperature", "expected_action"),
+    [
+        (None, 24, HVACAction.IDLE),
+        (26, 24, HVACAction.COOLING),
+        (22, 24, HVACAction.HEATING),
+        (24, 24, HVACAction.IDLE),
+    ],
+)
+async def test_ac_hvac_action_auto_mode(
+    hass: HomeAssistant,
+    indoor_temperature: float | None,
+    target_temperature: float,
+    expected_action: HVACAction,
+):
+    """Test hvac_action is estimated from the temperature delta in auto mode."""
+
+    mock_device = AC("0.0.0.0", 0, 0)
+    mock_device._power_state = True
+    mock_device._operational_mode = AC.OperationalMode.AUTO
+    mock_device._indoor_temperature = indoor_temperature
+    mock_device._target_temperature = target_temperature
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.apply = AsyncMock()
+    mock_coordinator.device = mock_device
+
+    climate_device = MideaClimateACDevice(hass, mock_coordinator, {})
+
+    assert climate_device.hvac_action == expected_action
+
+
+async def test_ac_hvac_action_defrosting(
+    hass: HomeAssistant,
+):
+    """Test hvac_action reports defrosting while heating with defrost active."""
+
+    mock_device = AC("0.0.0.0", 0, 0)
+    mock_device._power_state = True
+    mock_device._operational_mode = AC.OperationalMode.HEAT
+    mock_device._defrost_active = True
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.apply = AsyncMock()
+    mock_coordinator.device = mock_device
+
+    climate_device = MideaClimateACDevice(hass, mock_coordinator, {})
+
+    assert climate_device.hvac_action == HVACAction.DEFROSTING
+
+
+@pytest.mark.parametrize(
+    ("power_state", "operational_mode", "expected_action"),
+    [
+        (False, CC.OperationalMode.COOL, HVACAction.OFF),
+        (True, CC.OperationalMode.COOL, HVACAction.COOLING),
+        (True, CC.OperationalMode.HEAT, HVACAction.HEATING),
+        (True, CC.OperationalMode.DRY, HVACAction.DRYING),
+        (True, CC.OperationalMode.FAN, HVACAction.FAN),
+    ],
+)
+async def test_cc_hvac_action(
+    hass: HomeAssistant,
+    power_state: bool,
+    operational_mode: "CC.OperationalMode",
+    expected_action: HVACAction,
+):
+    """Test hvac_action reflects the mode for the CC device."""
+
+    mock_device = CC("0.0.0.0", 0, 0)
+    mock_device._power_state = power_state
+    mock_device._operational_mode = operational_mode
+
+    mock_coordinator = MagicMock()
+    mock_coordinator.apply = AsyncMock()
+    mock_coordinator.device = mock_device
+
+    climate_device = MideaClimateCCDevice(hass, mock_coordinator, {})
+
+    assert climate_device.hvac_action == expected_action

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -239,20 +239,27 @@ async def test_preset_modes(
 
 
 @pytest.mark.parametrize(
-    ("power_state", "operational_mode", "expected_action"),
+    ("power_state", "operational_mode", "indoor_temperature",
+     "target_temperature", "expected_action"),
     [
-        (False, AC.OperationalMode.COOL, HVACAction.OFF),
-        (True, AC.OperationalMode.COOL, HVACAction.COOLING),
-        (True, AC.OperationalMode.HEAT, HVACAction.HEATING),
-        (True, AC.OperationalMode.DRY, HVACAction.DRYING),
-        (True, AC.OperationalMode.SMART_DRY, HVACAction.DRYING),
-        (True, AC.OperationalMode.FAN_ONLY, HVACAction.FAN),
+        (False, AC.OperationalMode.COOL, 26, 24, HVACAction.OFF),
+        (True, AC.OperationalMode.COOL, 26, 24, HVACAction.COOLING),
+        (True, AC.OperationalMode.COOL, 22, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.COOL, 24, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
+        (True, AC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.HEAT, 24, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.DRY, None, 24, HVACAction.DRYING),
+        (True, AC.OperationalMode.SMART_DRY, None, 24, HVACAction.DRYING),
+        (True, AC.OperationalMode.FAN_ONLY, None, 24, HVACAction.FAN),
     ],
 )
 async def test_ac_hvac_action(
     hass: HomeAssistant,
     power_state: bool,
     operational_mode: AC.OperationalMode,
+    indoor_temperature: float | None,
+    target_temperature: float,
     expected_action: HVACAction,
 ):
     """Test hvac_action reflects the mode for the AC device."""
@@ -260,6 +267,8 @@ async def test_ac_hvac_action(
     mock_device = AC("0.0.0.0", 0, 0)
     mock_device._power_state = power_state
     mock_device._operational_mode = operational_mode
+    mock_device._indoor_temperature = indoor_temperature
+    mock_device._target_temperature = target_temperature
 
     mock_coordinator = MagicMock()
     mock_coordinator.apply = AsyncMock()
@@ -310,6 +319,8 @@ async def test_ac_hvac_action_defrosting(
     mock_device = AC("0.0.0.0", 0, 0)
     mock_device._power_state = True
     mock_device._operational_mode = AC.OperationalMode.HEAT
+    mock_device._indoor_temperature = 22
+    mock_device._target_temperature = 24
     mock_device._defrost_active = True
 
     mock_coordinator = MagicMock()
@@ -322,19 +333,24 @@ async def test_ac_hvac_action_defrosting(
 
 
 @pytest.mark.parametrize(
-    ("power_state", "operational_mode", "expected_action"),
+    ("power_state", "operational_mode", "indoor_temperature",
+     "target_temperature", "expected_action"),
     [
-        (False, CC.OperationalMode.COOL, HVACAction.OFF),
-        (True, CC.OperationalMode.COOL, HVACAction.COOLING),
-        (True, CC.OperationalMode.HEAT, HVACAction.HEATING),
-        (True, CC.OperationalMode.DRY, HVACAction.DRYING),
-        (True, CC.OperationalMode.FAN, HVACAction.FAN),
+        (False, CC.OperationalMode.COOL, 26, 24, HVACAction.OFF),
+        (True, CC.OperationalMode.COOL, 26, 24, HVACAction.COOLING),
+        (True, CC.OperationalMode.COOL, 22, 24, HVACAction.IDLE),
+        (True, CC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
+        (True, CC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
+        (True, CC.OperationalMode.DRY, None, 24, HVACAction.DRYING),
+        (True, CC.OperationalMode.FAN, None, 24, HVACAction.FAN),
     ],
 )
 async def test_cc_hvac_action(
     hass: HomeAssistant,
     power_state: bool,
     operational_mode: "CC.OperationalMode",
+    indoor_temperature: float | None,
+    target_temperature: float,
     expected_action: HVACAction,
 ):
     """Test hvac_action reflects the mode for the CC device."""
@@ -342,6 +358,8 @@ async def test_cc_hvac_action(
     mock_device = CC("0.0.0.0", 0, 0)
     mock_device._power_state = power_state
     mock_device._operational_mode = operational_mode
+    mock_device._indoor_temperature = indoor_temperature
+    mock_device._target_temperature = target_temperature
 
     mock_coordinator = MagicMock()
     mock_coordinator.apply = AsyncMock()


### PR DESCRIPTION
Closes #443

## Summary

Home Assistant's core `climate` domain has built-in icon rules keyed off the `hvac_action` state attribute (`cooling` -> blue snowflake, `heating` -> fire, `drying` -> water-percent, `fan` -> fan, `idle` -> clock, `off` -> power, `defrosting` -> melting snowflake — see `homeassistant/components/climate/icons.json` in HA core). This integration never implemented `hvac_action`, so the entity icon never reflected the actual running mode, unlike other climate integrations (e.g. versatile_thermostat) which get correct icons "for free" just by reporting this attribute.

This PR adds `hvac_action` to both `MideaClimateACDevice` and `MideaClimateCCDevice`:

- Added a `hvac_action` property to the base `MideaClimateDevice`, derived from `hvac_mode`: `OFF`/`COOLING`/`HEATING`/`DRYING`/`FAN` map directly from the corresponding `HVACMode`.
- For `AUTO` mode, since the msmart protocol doesn't expose real compressor state, `hvac_action` is estimated by comparing `indoor_temperature` to `target_temperature` (warmer than target -> cooling, cooler than target -> heating, otherwise idle).
- Added an override in `MideaClimateACDevice` that reports `DEFROSTING` instead of `HEATING` when the device's `defrost_active` flag is set (exposed by `msmart-ng` for AC units).

No custom icon assets or `icons.json` changes are needed — HA's built-in climate icon rules pick this up automatically once `hvac_action` is reported.

## Test plan

- [x] Added parametrized tests in `tests/test_climate.py` covering mode-based `hvac_action` for both AC and CC devices, the auto-mode temperature-delta heuristic, and the AC defrost override.
- [x] Full existing test suite still passes (`pytest tests/` — 68 passed).
- [x] Manually verified on a live Home Assistant instance: climate entity icon now shows the blue snowflake while cooling and switches appropriately for other modes.

## Final result 

<img width="241" height="122" alt="image" src="https://github.com/user-attachments/assets/93dc2d4e-0186-4784-9c95-eba58361e763" />
<img width="235" height="126" alt="image" src="https://github.com/user-attachments/assets/b450ac44-b51a-40de-9a08-d00eff92e679" />

