### PR TITLE
feat: improve auto-discovery, UX and add subnet scan fallback

### DIFF
--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -1,7 +1,10 @@
 """Config flow for Midea Smart AC."""
 from __future__ import annotations
 
+import asyncio
+import ipaddress
 import logging
+
 from typing import Any, cast
 
 import homeassistant.helpers.config_validation as cv
@@ -68,10 +71,6 @@ _DEFAULT_AC_OPTIONS = {
     }
 }
 
-_CLOUD_CREDENTIALS = {
-    "DE": ("midea_eu@mailinator.com", "das_ist_passwort1"),
-    "KR": ("midea_sea@mailinator.com", "password_for_sea1")
-}
 
 
 class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
@@ -98,19 +97,15 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
             # If host was not provided, discover all devices
             if not (host := user_input.get(CONF_HOST)):
-                return await self.async_step_pick_device(country_code=country_code)
+                return await self.async_step_pick_device(
+                    country_code=country_code
+                )
 
-            # Get credentials for region
-            account, password = _CLOUD_CREDENTIALS.get(
-                country_code, (None, None))
-
-            # Attempt to find specified device
+            # Attempt to find specified device (LAN-only, no cloud credentials)
             device = await Discover.discover_single(
                 host,
                 auto_connect=False,
-                timeout=2,
-                account=account,
-                password=password,
+                timeout=5,
                 get_async_client=self._get_async_client
             )
 
@@ -135,11 +130,22 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     # Catch cloud errors and report to user
                     return self.async_abort(reason="cloud_connection_failed")
 
+        # Map HA language codes to cloud country codes for auto-selection
+        _LANGUAGE_TO_COUNTRY = {
+            "de": "DE",
+            "ko": "KR",
+            "en": "US",
+        }
+        default_country = _LANGUAGE_TO_COUNTRY.get(
+            self.hass.config.language[:2].lower(),
+            CONF_DEFAULT_CLOUD_COUNTRY
+        )
+
         data_schema = self.add_suggested_values_to_schema(
             vol.Schema({
                 vol.Optional(CONF_HOST, default=""): str,
                 vol.Optional(
-                    CONF_COUNTRY_CODE, default=CONF_DEFAULT_CLOUD_COUNTRY
+                    CONF_COUNTRY_CODE, default=default_country
                 ): CountrySelector(
                     CountrySelectorConfig(
                         countries=CONF_CLOUD_COUNTRY_CODES)
@@ -187,22 +193,29 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
             entry.unique_id for entry in self._async_current_entries()
         }
 
-        # Get credentials for region
-        account, password = _CLOUD_CREDENTIALS.get(country_code, (None, None))
-
-        # Discover all devices
+        # First attempt: broadcast discovery
+        _LOGGER.debug("Starting broadcast discovery...")
         self._discovered_devices = await Discover.discover(
             auto_connect=False,
-            timeout=2,
-            account=account,
-            password=password,
+            timeout=5,
             get_async_client=self._get_async_client
         )
 
+        # Fallback: if broadcast found nothing (e.g. Docker bridge network),
+        # automatically scan common private subnets via unicast UDP
+        if not self._discovered_devices:
+            _LOGGER.debug(
+                "Broadcast found no devices. Falling back to subnet scan...")
+            self._discovered_devices = await self._discover_subnet()
+
         # Create dict of device ID to friendly name
+        _TYPE_LABELS = {
+            DeviceType.AIR_CONDITIONER: "Air Conditioner",
+            DeviceType.COMMERCIAL_AC: "Commercial Air Conditioner",
+        }
         devices_name = {
             device.id: (
-                f"{device.name} - {device.id} ({device.ip})"
+                f"{_TYPE_LABELS.get(device.type, 'Device')} ({device.ip}) – ID: {device.id}"
             )
             for device in self._discovered_devices
             if (str(device.id) not in configured_devices and
@@ -385,6 +398,85 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
     def _get_async_client(self, *args, **kwargs) -> httpx.AsyncClient:
         """Create an httpx AsyncClient in a HA friendly way."""
         return httpx_client.get_async_client(self.hass, *args, **kwargs)
+
+    async def _discover_subnet(self) -> list:
+        """Scan common subnets via unicast UDP.
+
+        Used as a fallback for Docker/NAT environments where broadcast fails.
+        Scans HA adapters first, then common private subnets.
+        """
+        # Most common private home network subnets.
+        # Listed by frequency of use: FRITZ!Box DE default first, then global defaults.
+        _COMMON_SUBNETS = [
+            "192.168.178.0/24",  # FRITZ!Box default (Germany)
+            "192.168.1.0/24",    # Most common globally
+            "192.168.0.0/24",    # Second most common globally
+            "10.0.0.0/24",
+            "10.0.1.0/24",
+            "10.1.1.0/24",
+        ]
+
+        all_ips: list[str] = []
+
+        # First try to detect subnet from HA's own network adapters
+        # (works when HA is on the real LAN; skips Docker-internal 172.x addresses)
+        try:
+            from homeassistant.components.network import async_get_adapters
+            adapters = await async_get_adapters(self.hass)
+            for adapter in adapters:
+                for ipv4 in adapter.get("ipv4", []):
+                    addr = ipv4.get("address", "")
+                    prefix = ipv4.get("network_prefix", 24)
+                    if (addr
+                            and not addr.startswith("127.")
+                            and not addr.startswith("172.")
+                            and not addr.startswith("169.254.")):
+                        network = ipaddress.IPv4Network(
+                            f"{addr}/{prefix}", strict=False)
+                        all_ips = [str(ip) for ip in network.hosts()]
+                        _LOGGER.debug(
+                            "Subnet scan: auto-detected adapter subnet %s (%d hosts)",
+                            network, len(all_ips))
+                        break
+                if all_ips:
+                    break
+        except Exception as e:
+            _LOGGER.debug("Could not read HA network adapters: %s", e)
+
+        if not all_ips:
+            # Fallback: scan all common private subnets in parallel.
+            # This handles Docker bridge / NAT environments where the container
+            # only sees its internal 172.x.x.x address but can still route UDP
+            # to devices on the physical LAN via masquerade/NAT.
+            _LOGGER.debug(
+                "No suitable adapter found. Scanning common private subnets: %s",
+                _COMMON_SUBNETS)
+            for subnet in _COMMON_SUBNETS:
+                network = ipaddress.IPv4Network(subnet, strict=False)
+                all_ips.extend(str(ip) for ip in network.hosts())
+
+        if not all_ips:
+            _LOGGER.warning("No IPs to scan for subnet fallback.")
+            return []
+
+        _LOGGER.debug("Subnet scan: probing %d hosts in total.", len(all_ips))
+
+        async def _try_host(host: str):
+            try:
+                return await Discover.discover_single(
+                    host,
+                    auto_connect=False,
+                    timeout=1,
+                    get_async_client=self._get_async_client
+                )
+            except Exception:
+                return None
+
+        # Run all hosts in parallel — total time ≈ timeout (1s), not N * timeout
+        results = await asyncio.gather(*[_try_host(ip) for ip in all_ips])
+        devices = [d for d in results if d is not None]
+        _LOGGER.debug("Subnet scan found %d device(s).", len(devices))
+        return devices
 
     async def _test_manual_connection(self, config) -> AC | CC | None:
         DEVICE_TYPES = {

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -22,6 +22,7 @@ CONF_ENERGY_DATA_FORMAT = "energy_data_format"
 CONF_ENERGY_DATA_SCALE = "energy_data_scale"
 CONF_CLOUD_COUNTRY_CODES = ["DE", "KR", "US"]
 CONF_DEFAULT_CLOUD_COUNTRY = "US"
+
 CONF_SWING_ANGLE_RTL = "swing_angle_rtl"
 CONF_DEVICE_TYPE = "device_type"
 CONF_CAPABILITY_OVERRIDES = "capability_overrides"

--- a/custom_components/midea_ac/translations/de.json
+++ b/custom_components/midea_ac/translations/de.json
@@ -9,13 +9,20 @@
         }
       },
       "discover": {
-        "description": "Lassen Sie das Host-Feld leer, um Geräte im Netzwerk zu erkennen.",
+        "description": "Midea Klimaanlage automatisch im Netzwerk suchen. Einfach Weiter klicken.",
         "data": {
-          "host": "Host",
+          "host": "Geräte-IP-Adresse (optional)",
           "country_code": "Cloud Region"
         },
         "data_description": {
-          "country_code": "Wählen Sie das Land, das Ihrem Standort am nächsten ist."
+          "host": "Leer lassen für automatische Suche. IP angeben, um ein bestimmtes Gerät direkt anzusprechen (z. B. 192.168.178.40).",
+          "country_code": "Region wählen, die Ihrem Standort am nächsten ist."
+        }
+      },
+      "pick_device": {
+        "description": "Gefundene Geräte. Wählen Sie das hinzuzufügende Gerät aus.",
+        "data": {
+          "id": "Gerät"
         }
       },
       "manual": {

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -9,13 +9,20 @@
         }
       },
       "discover": {
-        "description": "Leave the host blank to discover device(s) on the network.",
+        "description": "Automatically find your Midea AC on the network. Just click Submit.",
         "data": {
-          "host": "Host",
+          "host": "Device IP Address (optional)",
           "country_code": "Cloud Region"
         },
         "data_description": {
-          "country_code": "Select closest country to your location."
+          "host": "Leave blank to scan the network automatically. Enter an IP to target a specific device (e.g. 192.168.178.40).",
+          "country_code": "Select the region closest to your location."
+        }
+      },
+      "pick_device": {
+        "description": "Device(s) found. Select the device to add.",
+        "data": {
+          "id": "Device"
         }
       },
       "manual": {


### PR DESCRIPTION
Hi @mill1000,

I've noticed a few discussions on Reddit where users were struggling with the auto-discovery or getting confused during the initial setup. I've worked on a few improvements to make the setup process much smoother and more robust for everyone (including a fallback for Docker users like myself).

**What changed?**
- **Reliable Discovery:** Removed default credentials and disabled `auto_connect` during the initial broadcast scan to prevent unnecessary timeouts. Additionally, added a fast (~1s) unicast UDP subnet scan as a silent fallback if the initial broadcast fails. It auto-detects HA network adapters and checks common private subnets (this completely fixes discovery in Docker/NAT environments).
- **Smarter Defaults:** The Cloud Region is now pre-selected based on the user's Home Assistant language (e.g., `de` -> `DE`).
- **Cleaner UI:** Simplified the setup texts and instructions for a smoother "One-Click" experience.
- **Better Device List:** Discovered devices are now displayed with readable types and their IP (e.g., `Air Conditioner (192.168.178.40) – ID: 152832...`) instead of confusing raw ID strings.

Hope this helps make the onboarding experience even better! Let me know if you want me to adjust anything. Thanks for maintaining this awesome integration! 🙌