### PR TITLE
Display already-configured devices when discovery finds no new device

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 __pycache__/
 .venv/
 .vscode/
-.idea/
 .devcontainer/devcontainer-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 __pycache__/
 .venv/
 .vscode/
+.idea/
 .devcontainer/devcontainer-lock.json

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -257,9 +257,10 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     self.hass.config.language[:2].lower(),
                     _ALREADY_CONFIGURED_LABELS["en"]
                 )
-                already_configured_message = (
-                    f"\n\n{label}: " + ", ".join(already_configured_names)
+                bullets = "\n".join(
+                    f"- {name}" for name in already_configured_names
                 )
+                already_configured_message = f"\n\n{label}:\n{bullets}"
 
             return self.async_abort(
                 reason="no_devices_found",

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -73,6 +73,35 @@ _CLOUD_CREDENTIALS = {
     "KR": ("midea_sea@mailinator.com", "password_for_sea1")
 }
 
+# Label prefixed to the list of already-configured devices surfaced when
+# discovery finds no new devices, keyed by the two-letter language code.
+_ALREADY_CONFIGURED_LABELS = {
+    "bg": "Вече конфигурирани в тази мрежа",
+    "ca": "Ja configurats en aquesta xarxa",
+    "cs": "Již nakonfigurováno v této síti",
+    "de": "Bereits im Netzwerk konfiguriert",
+    "en": "Already configured on this network",
+    "es": "Ya configurados en esta red",
+    "eu": "Sare honetan jadanik konfiguratuta",
+    "fr": "Déjà configuré sur ce réseau",
+    "hr": "Već konfigurirano na ovoj mreži",
+    "hu": "Már konfigurálva ezen a hálózaton",
+    "it": "Già configurato su questa rete",
+    "ko": "이 네트워크에 이미 구성됨",
+    "mk": "Веќе конфигурирано на оваа мрежа",
+    "nb": "Allerede konfigurert på dette nettverket",
+    "nl": "Al geconfigureerd op dit netwerk",
+    "pl": "Już skonfigurowane w tej sieci",
+    "pt": "Já configurado nesta rede",
+    "ro": "Deja configurat în această rețea",
+    "ru": "Уже настроено в этой сети",
+    "sk": "Už nakonfigurované v tejto sieti",
+    "sl": "Že konfigurirano v tem omrežju",
+    "tr": "Bu ağda zaten yapılandırılmış",
+    "uk": "Вже налаштовано в цій мережі",
+    "zh": "此网络中已配置",
+}
+
 
 class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Midea Smart AC."""
@@ -211,7 +240,33 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         # Check if there is at least one device
         if len(devices_name) == 0:
-            return self.async_abort(reason="no_devices_found")
+            # Devices found on the network that are already set up. Surfacing
+            # these helps a user realize "no new devices" doesn't mean
+            # discovery is broken - the device they're looking for may
+            # already be added.
+            already_configured_names = [
+                f"{device.name} - {device.id} ({device.ip})"
+                for device in self._discovered_devices
+                if (str(device.id) in configured_devices and
+                    device.type in [DeviceType.AIR_CONDITIONER, DeviceType.COMMERCIAL_AC])
+            ]
+
+            already_configured_message = ""
+            if already_configured_names:
+                label = _ALREADY_CONFIGURED_LABELS.get(
+                    self.hass.config.language[:2].lower(),
+                    _ALREADY_CONFIGURED_LABELS["en"]
+                )
+                already_configured_message = (
+                    f"\n\n{label}: " + ", ".join(already_configured_names)
+                )
+
+            return self.async_abort(
+                reason="no_devices_found",
+                description_placeholders={
+                    "already_configured": already_configured_message
+                }
+            )
 
         data_schema = vol.Schema({
             vol.Required(CONF_ID): vol.In(devices_name)

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -199,47 +199,40 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
             get_async_client=self._get_async_client
         )
 
-        # Create dict of device ID to friendly name
-        devices_name = {
-            device.id: (
-                f"{device.name} - {device.id} ({device.ip})"
-            )
+        # Create a dict of supported devices
+        supported_devices = {
+            device.id: f"{device.name} - {device.id} ({device.ip})"
             for device in self._discovered_devices
-            if (str(device.id) not in configured_devices and
-                device.type in [DeviceType.AIR_CONDITIONER, DeviceType.COMMERCIAL_AC])
+            if device.type in [DeviceType.AIR_CONDITIONER, DeviceType.COMMERCIAL_AC]
         }
 
-        # Check if there is at least one device
-        if len(devices_name) == 0:
-            # Devices found on the network that are already set up. Surfacing
-            # these helps a user realize "no new devices" doesn't mean
-            # discovery is broken - the device they're looking for may
-            # already be added.
-            already_configured_names = [
-                f"{device.name} - {device.id} ({device.ip})"
-                for device in self._discovered_devices
-                if (str(device.id) in configured_devices and
-                    device.type in [DeviceType.AIR_CONDITIONER, DeviceType.COMMERCIAL_AC])
-            ]
-
-            if already_configured_names:
-                return self.async_abort(
-                    reason="already_configured_devices_found",
-                    description_placeholders={
-                        "devices": "\n".join(
-                            f"- {name}" for name in already_configured_names)
-                    }
-                )
-
+        # No supported devices found
+        if len(supported_devices) == 0:
             return self.async_abort(reason="no_devices_found")
 
-        data_schema = vol.Schema({
-            vol.Required(CONF_ID): vol.In(devices_name)
-        })
+        # Show device picker if new devices found
+        new_devices = {
+            dev_id: name
+            for dev_id, name in supported_devices.items()
+            if str(dev_id) not in configured_devices
+        }
+        if len(new_devices):
+            return self.async_show_form(
+                step_id="pick_device",
+                data_schema=vol.Schema({
+                    vol.Required(CONF_ID): vol.In(new_devices)
+                })
+            )
 
-        return self.async_show_form(
-            step_id="pick_device",
-            data_schema=data_schema
+        # No new devices, show existing devices
+        return self.async_abort(
+            reason="already_configured_devices_found",
+            description_placeholders={
+                "devices": "\n".join(
+                    f"- {name}"
+                    for name in supported_devices.values()
+                )
+            }
         )
 
     async def async_step_show_token_key(

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -73,35 +73,6 @@ _CLOUD_CREDENTIALS = {
     "KR": ("midea_sea@mailinator.com", "password_for_sea1")
 }
 
-# Label prefixed to the list of already-configured devices surfaced when
-# discovery finds no new devices, keyed by the two-letter language code.
-_ALREADY_CONFIGURED_LABELS = {
-    "bg": "Вече конфигурирани в тази мрежа",
-    "ca": "Ja configurats en aquesta xarxa",
-    "cs": "Již nakonfigurováno v této síti",
-    "de": "Bereits im Netzwerk konfiguriert",
-    "en": "Already configured on this network",
-    "es": "Ya configurados en esta red",
-    "eu": "Sare honetan jadanik konfiguratuta",
-    "fr": "Déjà configuré sur ce réseau",
-    "hr": "Već konfigurirano na ovoj mreži",
-    "hu": "Már konfigurálva ezen a hálózaton",
-    "it": "Già configurato su questa rete",
-    "ko": "이 네트워크에 이미 구성됨",
-    "mk": "Веќе конфигурирано на оваа мрежа",
-    "nb": "Allerede konfigurert på dette nettverket",
-    "nl": "Al geconfigureerd op dit netwerk",
-    "pl": "Już skonfigurowane w tej sieci",
-    "pt": "Já configurado nesta rede",
-    "ro": "Deja configurat în această rețea",
-    "ru": "Уже настроено в этой сети",
-    "sk": "Už nakonfigurované v tejto sieti",
-    "sl": "Že konfigurirano v tem omrežju",
-    "tr": "Bu ağda zaten yapılandırılmış",
-    "uk": "Вже налаштовано в цій мережі",
-    "zh": "此网络中已配置",
-}
-
 
 class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Midea Smart AC."""
@@ -251,23 +222,16 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
                     device.type in [DeviceType.AIR_CONDITIONER, DeviceType.COMMERCIAL_AC])
             ]
 
-            already_configured_message = ""
             if already_configured_names:
-                label = _ALREADY_CONFIGURED_LABELS.get(
-                    self.hass.config.language[:2].lower(),
-                    _ALREADY_CONFIGURED_LABELS["en"]
+                return self.async_abort(
+                    reason="already_configured_devices_found",
+                    description_placeholders={
+                        "devices": "\n".join(
+                            f"- {name}" for name in already_configured_names)
+                    }
                 )
-                bullets = "\n".join(
-                    f"- {name}" for name in already_configured_names
-                )
-                already_configured_message = f"\n\n{label}:\n{bullets}"
 
-            return self.async_abort(
-                reason="no_devices_found",
-                description_placeholders={
-                    "already_configured": already_configured_message
-                }
-            )
+            return self.async_abort(reason="no_devices_found")
 
         data_schema = vol.Schema({
             vol.Required(CONF_ID): vol.In(devices_name)

--- a/custom_components/midea_ac/translations/bg.json
+++ b/custom_components/midea_ac/translations/bg.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Устройството вече е конфигурирано.",
+      "already_configured_devices_found": "Няма намерени нови устройства в мрежата.\n\nВече конфигурирани в тази мрежа:\n{devices}",
       "cannot_connect": "Не можа да се осъществи връзка.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Няма намерени нови устройства в мрежата.{already_configured}",
+      "no_devices_found": "Няма намерени поддържани устройства в мрежата.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/bg.json
+++ b/custom_components/midea_ac/translations/bg.json
@@ -58,7 +58,7 @@
       "already_configured": "Устройството вече е конфигурирано.",
       "cannot_connect": "Не можа да се осъществи връзка.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Няма намерени поддържани устройства в мрежата.",
+      "no_devices_found": "Няма намерени нови устройства в мрежата.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/ca.json
+++ b/custom_components/midea_ac/translations/ca.json
@@ -58,7 +58,7 @@
       "already_configured": "El dispositiu ja ha estat configurat.",
       "cannot_connect": "No s'ha pogut realitzar una connexió.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "No s'han trobat dispositius compatibles a la xarxa.",
+      "no_devices_found": "No s'han trobat dispositius nous a la xarxa.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/ca.json
+++ b/custom_components/midea_ac/translations/ca.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "El dispositiu ja ha estat configurat.",
+      "already_configured_devices_found": "No s'han trobat dispositius nous a la xarxa.\n\nJa configurats en aquesta xarxa:\n{devices}",
       "cannot_connect": "No s'ha pogut realitzar una connexió.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "No s'han trobat dispositius nous a la xarxa.{already_configured}",
+      "no_devices_found": "No s'han trobat dispositius compatibles a la xarxa.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/cs.json
+++ b/custom_components/midea_ac/translations/cs.json
@@ -58,7 +58,7 @@
       "already_configured": "ID zařízení již bylo nakonfigurováno.",
       "cannot_connect": "Nepodařilo se vytvořit spojení.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "V síti nebyla nalezena žádná podporovaná zařízení.",
+      "no_devices_found": "V síti nebyla nalezena žádná nová zařízení.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/cs.json
+++ b/custom_components/midea_ac/translations/cs.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "ID zařízení již bylo nakonfigurováno.",
+      "already_configured_devices_found": "V síti nebyla nalezena žádná nová zařízení.\n\nJiž nakonfigurováno v této síti:\n{devices}",
       "cannot_connect": "Nepodařilo se vytvořit spojení.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "V síti nebyla nalezena žádná nová zařízení.{already_configured}",
+      "no_devices_found": "V síti nebyla nalezena žádná podporovaná zařízení.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/de.json
+++ b/custom_components/midea_ac/translations/de.json
@@ -59,7 +59,7 @@
       "already_configured": "Das Gerät wurde bereits konfiguriert.",
       "cannot_connect": "Es konnte keine Verbindung hergestellt werden.",
       "cloud_connection_failed": "Es konnte keine Verbindung zur Cloud hergestellt werden.",
-      "no_devices_found": "Keine unterstützten Geräte im Netzwerk gefunden.",
+      "no_devices_found": "Keine neuen Geräte im Netzwerk gefunden.{already_configured}",
       "reconfigure_successful": "Gerät erfolgreich neu konfiguriert."
     },
     "error": {

--- a/custom_components/midea_ac/translations/de.json
+++ b/custom_components/midea_ac/translations/de.json
@@ -57,9 +57,10 @@
     },
     "abort": {
       "already_configured": "Das Gerät wurde bereits konfiguriert.",
+      "already_configured_devices_found": "Keine neuen Geräte im Netzwerk gefunden.\n\nBereits im Netzwerk konfiguriert:\n{devices}",
       "cannot_connect": "Es konnte keine Verbindung hergestellt werden.",
       "cloud_connection_failed": "Es konnte keine Verbindung zur Cloud hergestellt werden.",
-      "no_devices_found": "Keine neuen Geräte im Netzwerk gefunden.{already_configured}",
+      "no_devices_found": "Keine unterstützten Geräte im Netzwerk gefunden.",
       "reconfigure_successful": "Gerät erfolgreich neu konfiguriert."
     },
     "error": {

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -57,9 +57,10 @@
     },
     "abort": {
       "already_configured": "The device has already been configured.",
+      "already_configured_devices_found": "No new devices found on the network.\n\nAlready configured on this network:\n{devices}",
       "cannot_connect": "Device connection could not be made.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "No new devices found on the network.{already_configured}",
+      "no_devices_found": "No supported devices found on the network.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -59,7 +59,7 @@
       "already_configured": "The device has already been configured.",
       "cannot_connect": "Device connection could not be made.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "No supported devices found on the network.",
+      "no_devices_found": "No new devices found on the network.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/es.json
+++ b/custom_components/midea_ac/translations/es.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "El dispositivo ya ha sido configurado.",
+      "already_configured_devices_found": "No se han encontrado dispositivos nuevos en la red.\n\nYa configurados en esta red:\n{devices}",
       "cannot_connect": "No se pudo realizar una connexión.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "No se han encontrado dispositivos nuevos en la red.{already_configured}",
+      "no_devices_found": "No se han encontrado dispositivos compatibles en la red.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/es.json
+++ b/custom_components/midea_ac/translations/es.json
@@ -58,7 +58,7 @@
       "already_configured": "El dispositivo ya ha sido configurado.",
       "cannot_connect": "No se pudo realizar una connexión.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "No se han encontrado dispositivos compatibles en la red.",
+      "no_devices_found": "No se han encontrado dispositivos nuevos en la red.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/eu.json
+++ b/custom_components/midea_ac/translations/eu.json
@@ -58,7 +58,7 @@
       "already_configured": "Gailua dagoeneko konfiguratuta dago.",
       "cannot_connect": "Ezin izan da konexiorik egin.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Ez da onartutako gailurik aurkitu sarean.",
+      "no_devices_found": "Ez da gailu berririk aurkitu sarean.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/eu.json
+++ b/custom_components/midea_ac/translations/eu.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Gailua dagoeneko konfiguratuta dago.",
+      "already_configured_devices_found": "Ez da gailu berririk aurkitu sarean.\n\nSare honetan jadanik konfiguratuta:\n{devices}",
       "cannot_connect": "Ezin izan da konexiorik egin.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Ez da gailu berririk aurkitu sarean.{already_configured}",
+      "no_devices_found": "Ez da onartutako gailurik aurkitu sarean.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/fr.json
+++ b/custom_components/midea_ac/translations/fr.json
@@ -58,7 +58,7 @@
       "already_configured": "L'appareil a déjà été configuré.",
       "cannot_connect": "La connexion n'a pas pu être établie.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Aucun appareil compatible trouvé sur le réseau.",
+      "no_devices_found": "Aucun nouvel appareil trouvé sur le réseau.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/fr.json
+++ b/custom_components/midea_ac/translations/fr.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "L'appareil a déjà été configuré.",
+      "already_configured_devices_found": "Aucun nouvel appareil trouvé sur le réseau.\n\nDéjà configuré sur ce réseau:\n{devices}",
       "cannot_connect": "La connexion n'a pas pu être établie.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Aucun nouvel appareil trouvé sur le réseau.{already_configured}",
+      "no_devices_found": "Aucun appareil compatible trouvé sur le réseau.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/hr.json
+++ b/custom_components/midea_ac/translations/hr.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Uređaj je već konfiguriran.",
+      "already_configured_devices_found": "Na mreži nisu pronađeni novi uređaji.\n\nVeć konfigurirano na ovoj mreži:\n{devices}",
       "cannot_connect": "Nije bilo moguće uspostaviti vezu.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Na mreži nisu pronađeni novi uređaji.{already_configured}",
+      "no_devices_found": "Na mreži nisu pronađeni podržani uređaji.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/hr.json
+++ b/custom_components/midea_ac/translations/hr.json
@@ -58,7 +58,7 @@
       "already_configured": "Uređaj je već konfiguriran.",
       "cannot_connect": "Nije bilo moguće uspostaviti vezu.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Na mreži nisu pronađeni podržani uređaji.",
+      "no_devices_found": "Na mreži nisu pronađeni novi uređaji.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/hu.json
+++ b/custom_components/midea_ac/translations/hu.json
@@ -58,7 +58,7 @@
       "already_configured": "Az eszköz már konfigurálva lett.",
       "cannot_connect": "Nem sikerült a csatlakozás.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Nem található támogatott eszköz a hálózaton.",
+      "no_devices_found": "Nem található új eszköz a hálózaton.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/hu.json
+++ b/custom_components/midea_ac/translations/hu.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Az eszköz már konfigurálva lett.",
+      "already_configured_devices_found": "Nem található új eszköz a hálózaton.\n\nMár konfigurálva ezen a hálózaton:\n{devices}",
       "cannot_connect": "Nem sikerült a csatlakozás.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Nem található új eszköz a hálózaton.{already_configured}",
+      "no_devices_found": "Nem található támogatott eszköz a hálózaton.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/it.json
+++ b/custom_components/midea_ac/translations/it.json
@@ -58,7 +58,7 @@
       "already_configured": "Il dispositivo è già stato configurato.",
       "cannot_connect": "Connessione non riuscita.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Nessun dispositivo supportato è stato trovato nella rete.",
+      "no_devices_found": "Nessun nuovo dispositivo trovato nella rete.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/it.json
+++ b/custom_components/midea_ac/translations/it.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Il dispositivo è già stato configurato.",
+      "already_configured_devices_found": "Nessun nuovo dispositivo trovato nella rete.\n\nGià configurato su questa rete:\n{devices}",
       "cannot_connect": "Connessione non riuscita.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Nessun nuovo dispositivo trovato nella rete.{already_configured}",
+      "no_devices_found": "Nessun dispositivo supportato è stato trovato nella rete.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/ko.json
+++ b/custom_components/midea_ac/translations/ko.json
@@ -58,7 +58,7 @@
       "already_configured": "기기가 이미 설정되었습니다.",
       "cannot_connect": "연결을 할 수 없습니다.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "네트워크상에서 지원되는 기기를 찾을 수 없습니다.",
+      "no_devices_found": "네트워크에서 새 기기를 찾을 수 없습니다.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/ko.json
+++ b/custom_components/midea_ac/translations/ko.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "기기가 이미 설정되었습니다.",
+      "already_configured_devices_found": "네트워크에서 새 기기를 찾을 수 없습니다.\n\n이 네트워크에 이미 구성됨:\n{devices}",
       "cannot_connect": "연결을 할 수 없습니다.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "네트워크에서 새 기기를 찾을 수 없습니다.{already_configured}",
+      "no_devices_found": "네트워크상에서 지원되는 기기를 찾을 수 없습니다.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/mk.json
+++ b/custom_components/midea_ac/translations/mk.json
@@ -57,9 +57,10 @@
     },
     "abort": {
       "already_configured": "Уредот веќе е конфигуриран.",
+      "already_configured_devices_found": "Не се пронајдени нови уреди на мрежата.\n\nВеќе конфигурирано на оваа мрежа:\n{devices}",
       "cannot_connect": "Не може да се воспостави врска со уредот.",
       "cloud_connection_failed": "Не може да се воспостави врска со облакот.",
-      "no_devices_found": "Не се пронајдени нови уреди на мрежата.{already_configured}",
+      "no_devices_found": "Не се пронајдени поддржани уреди на мрежата.",
       "reconfigure_successful": "Уредот е успешно повторно конфигуриран."
     },
     "error": {

--- a/custom_components/midea_ac/translations/mk.json
+++ b/custom_components/midea_ac/translations/mk.json
@@ -59,7 +59,7 @@
       "already_configured": "Уредот веќе е конфигуриран.",
       "cannot_connect": "Не може да се воспостави врска со уредот.",
       "cloud_connection_failed": "Не може да се воспостави врска со облакот.",
-      "no_devices_found": "Не се пронајдени поддржани уреди на мрежата.",
+      "no_devices_found": "Не се пронајдени нови уреди на мрежата.{already_configured}",
       "reconfigure_successful": "Уредот е успешно повторно конфигуриран."
     },
     "error": {

--- a/custom_components/midea_ac/translations/nb.json
+++ b/custom_components/midea_ac/translations/nb.json
@@ -58,7 +58,7 @@
       "already_configured": "Enheten er allerede konfigurert.",
       "cannot_connect": "Det kunne ikke opprettes en forbindelse.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Finner ingen støttede enheter på nettverket.",
+      "no_devices_found": "Fant ingen nye enheter på nettverket.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/nb.json
+++ b/custom_components/midea_ac/translations/nb.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Enheten er allerede konfigurert.",
+      "already_configured_devices_found": "Fant ingen nye enheter på nettverket.\n\nAllerede konfigurert på dette nettverket:\n{devices}",
       "cannot_connect": "Det kunne ikke opprettes en forbindelse.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Fant ingen nye enheter på nettverket.{already_configured}",
+      "no_devices_found": "Finner ingen støttede enheter på nettverket.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/nl.json
+++ b/custom_components/midea_ac/translations/nl.json
@@ -57,9 +57,10 @@
     },
     "abort": {
       "already_configured": "Dit apparaat is al ingesteld.",
+      "already_configured_devices_found": "Geen nieuwe apparaten gevonden op het netwerk.\n\nAl geconfigureerd op dit netwerk:\n{devices}",
       "cannot_connect": "Het apparaat kon niet worden bereikt.",
       "cloud_connection_failed": "Cloudverbinding is mislukt.",
-      "no_devices_found": "Geen nieuwe apparaten gevonden op het netwerk.{already_configured}",
+      "no_devices_found": "Geen ondersteunde apparaten gevonden op het netwerk.",
       "reconfigure_successful": "Apparaat succesvol opnieuw ingesteld."
     },
     "error": {

--- a/custom_components/midea_ac/translations/nl.json
+++ b/custom_components/midea_ac/translations/nl.json
@@ -59,7 +59,7 @@
       "already_configured": "Dit apparaat is al ingesteld.",
       "cannot_connect": "Het apparaat kon niet worden bereikt.",
       "cloud_connection_failed": "Cloudverbinding is mislukt.",
-      "no_devices_found": "Geen ondersteunde apparaten gevonden op het netwerk.",
+      "no_devices_found": "Geen nieuwe apparaten gevonden op het netwerk.{already_configured}",
       "reconfigure_successful": "Apparaat succesvol opnieuw ingesteld."
     },
     "error": {

--- a/custom_components/midea_ac/translations/pl.json
+++ b/custom_components/midea_ac/translations/pl.json
@@ -58,7 +58,7 @@
       "already_configured": "To urządzenie zostało już skonfigurowane.",
       "cannot_connect": "Nie udało się nawiązać połączenia.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Nie znaleziono wspieranego urządzenia w sieci.",
+      "no_devices_found": "Nie znaleziono nowych urządzeń w sieci.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/pl.json
+++ b/custom_components/midea_ac/translations/pl.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "To urządzenie zostało już skonfigurowane.",
+      "already_configured_devices_found": "Nie znaleziono nowych urządzeń w sieci.\n\nJuż skonfigurowane w tej sieci:\n{devices}",
       "cannot_connect": "Nie udało się nawiązać połączenia.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Nie znaleziono nowych urządzeń w sieci.{already_configured}",
+      "no_devices_found": "Nie znaleziono wspieranego urządzenia w sieci.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/pt.json
+++ b/custom_components/midea_ac/translations/pt.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "O dispositivo já está configurado.",
+      "already_configured_devices_found": "Não foram encontrados novos dispositivos na rede.\n\nJá configurado nesta rede:\n{devices}",
       "cannot_connect": "Não foi possível conectar.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Não foram encontrados novos dispositivos na rede.{already_configured}",
+      "no_devices_found": "Não foram encontrados dispositivos compatíveis na sua rede.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/pt.json
+++ b/custom_components/midea_ac/translations/pt.json
@@ -58,7 +58,7 @@
       "already_configured": "O dispositivo já está configurado.",
       "cannot_connect": "Não foi possível conectar.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Não foram encontrados dispositivos compatíveis na sua rede.",
+      "no_devices_found": "Não foram encontrados novos dispositivos na rede.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/ro.json
+++ b/custom_components/midea_ac/translations/ro.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Dispozitivul este deja configurat.",
+      "already_configured_devices_found": "Nu s-au găsit dispozitive noi în rețea.\n\nDeja configurat în această rețea:\n{devices}",
       "cannot_connect": "Nu s-a putut realiza conexiunea.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Nu s-au găsit dispozitive noi în rețea.{already_configured}",
+      "no_devices_found": "Nu s-au găsit dispozitive compatibile în rețea.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/ro.json
+++ b/custom_components/midea_ac/translations/ro.json
@@ -58,7 +58,7 @@
       "already_configured": "Dispozitivul este deja configurat.",
       "cannot_connect": "Nu s-a putut realiza conexiunea.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Nu s-au găsit dispozitive compatibile în rețea.",
+      "no_devices_found": "Nu s-au găsit dispozitive noi în rețea.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/ru.json
+++ b/custom_components/midea_ac/translations/ru.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Устройство уже настроено.",
+      "already_configured_devices_found": "Новые устройства в сети не найдены.\n\nУже настроено в этой сети:\n{devices}",
       "cannot_connect": "Не удалось установить соединение.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Новые устройства в сети не найдены.{already_configured}",
+      "no_devices_found": "Поддерживаемые устройства не найдены.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/ru.json
+++ b/custom_components/midea_ac/translations/ru.json
@@ -58,7 +58,7 @@
       "already_configured": "Устройство уже настроено.",
       "cannot_connect": "Не удалось установить соединение.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Поддерживаемые устройства не найдены.",
+      "no_devices_found": "Новые устройства в сети не найдены.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/sk.json
+++ b/custom_components/midea_ac/translations/sk.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "ID zariadenia už bolo nakonfigurované.",
+      "already_configured_devices_found": "V sieti sa nenašli žiadne nové zariadenia.\n\nUž nakonfigurované v tejto sieti:\n{devices}",
       "cannot_connect": "Nepodarilo sa vytvoriť spojenie.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "V sieti sa nenašli žiadne nové zariadenia.{already_configured}",
+      "no_devices_found": "V sieti sa nenašli žiadne podporované zariadenia.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/sk.json
+++ b/custom_components/midea_ac/translations/sk.json
@@ -58,7 +58,7 @@
       "already_configured": "ID zariadenia už bolo nakonfigurované.",
       "cannot_connect": "Nepodarilo sa vytvoriť spojenie.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "V sieti sa nenašli žiadne podporované zariadenia.",
+      "no_devices_found": "V sieti sa nenašli žiadne nové zariadenia.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/sl.json
+++ b/custom_components/midea_ac/translations/sl.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Ta naprava je že bila nastavljena.",
+      "already_configured_devices_found": "V omrežju ni bilo najdenih novih naprav.\n\nŽe konfigurirano v tem omrežju:\n{devices}",
       "cannot_connect": "Povezave ni bilo mogoče vspoztaviti.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "V omrežju ni bilo najdenih novih naprav.{already_configured}",
+      "no_devices_found": "Podprtih naprav ni bilo mogoče najti na omrežju.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/sl.json
+++ b/custom_components/midea_ac/translations/sl.json
@@ -58,7 +58,7 @@
       "already_configured": "Ta naprava je že bila nastavljena.",
       "cannot_connect": "Povezave ni bilo mogoče vspoztaviti.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Podprtih naprav ni bilo mogoče najti na omrežju.",
+      "no_devices_found": "V omrežju ni bilo najdenih novih naprav.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/tr.json
+++ b/custom_components/midea_ac/translations/tr.json
@@ -58,7 +58,7 @@
       "already_configured": "Cihaz zaten yapılandırılmış.",
       "cannot_connect": "Bağlantı kurulamadı.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Ağda desteklenen bir cihaz bulunamadı.",
+      "no_devices_found": "Ağda yeni cihaz bulunamadı.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/tr.json
+++ b/custom_components/midea_ac/translations/tr.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Cihaz zaten yapılandırılmış.",
+      "already_configured_devices_found": "Ağda yeni cihaz bulunamadı.\n\nBu ağda zaten yapılandırılmış:\n{devices}",
       "cannot_connect": "Bağlantı kurulamadı.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "Ağda yeni cihaz bulunamadı.{already_configured}",
+      "no_devices_found": "Ağda desteklenen bir cihaz bulunamadı.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/uk.json
+++ b/custom_components/midea_ac/translations/uk.json
@@ -58,7 +58,7 @@
       "already_configured": "Пристрій вже налаштовано.",
       "cannot_connect": "Не вдалося встановити зʼєднання.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "У мережі не знайдено підтримуваних пристроїв.",
+      "no_devices_found": "У мережі не знайдено нових пристроїв.{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/uk.json
+++ b/custom_components/midea_ac/translations/uk.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "Пристрій вже налаштовано.",
+      "already_configured_devices_found": "У мережі не знайдено нових пристроїв.\n\nВже налаштовано в цій мережі:\n{devices}",
       "cannot_connect": "Не вдалося встановити зʼєднання.",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "У мережі не знайдено нових пристроїв.{already_configured}",
+      "no_devices_found": "У мережі не знайдено підтримуваних пристроїв.",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/zh-Hans.json
+++ b/custom_components/midea_ac/translations/zh-Hans.json
@@ -58,7 +58,7 @@
       "already_configured": "已存在的设备。",
       "cannot_connect": "无法连接到设备。",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "未发现支持的设备。",
+      "no_devices_found": "网络上未发现新设备。{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/zh-Hans.json
+++ b/custom_components/midea_ac/translations/zh-Hans.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "已存在的设备。",
+      "already_configured_devices_found": "网络上未发现新设备。\n\n此网络中已配置:\n{devices}",
       "cannot_connect": "无法连接到设备。",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "网络上未发现新设备。{already_configured}",
+      "no_devices_found": "未发现支持的设备。",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/zh-Hant.json
+++ b/custom_components/midea_ac/translations/zh-Hant.json
@@ -56,9 +56,10 @@
     },
     "abort": {
       "already_configured": "已存在的設備。",
+      "already_configured_devices_found": "網路上未發現新裝置。\n\n此網絡中已配置:\n{devices}",
       "cannot_connect": "無法連結到設備。",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "網路上未發現新裝置。{already_configured}",
+      "no_devices_found": "未發現支援的設備。",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/custom_components/midea_ac/translations/zh-Hant.json
+++ b/custom_components/midea_ac/translations/zh-Hant.json
@@ -58,7 +58,7 @@
       "already_configured": "已存在的設備。",
       "cannot_connect": "無法連結到設備。",
       "cloud_connection_failed": "Cloud connection could not be made.",
-      "no_devices_found": "未發現支援的設備。",
+      "no_devices_found": "網路上未發現新裝置。{already_configured}",
       "reconfigure_successful": "Device successfully reconfigured."
     },
     "error": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -49,19 +49,6 @@ async def test_config_flow_options(hass: HomeAssistant) -> None:
     assert not manual_form_result["errors"]
 
 
-def _mock_discovered_device(
-    id: int, ip: str, name: str,
-    device_type: DeviceType = DeviceType.AIR_CONDITIONER
-) -> MagicMock:
-    """Build a fake device as returned by Discover.discover()."""
-    device = MagicMock()
-    device.id = id
-    device.ip = ip
-    device.name = name
-    device.type = device_type
-    return device
-
-
 async def test_pick_device_flow_no_devices_found(hass: HomeAssistant) -> None:
     """Test the discover flow aborts with no_devices_found when nothing is discovered."""
     result = await hass.config_entries.flow.async_init(
@@ -88,21 +75,25 @@ async def test_pick_device_flow_already_configured_devices_found(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the discover flow surfaces already-configured devices when no new device is found."""
+    # Add config entry for existing device
     mock_config_entry.add_to_hass(hass)
-
-    discovered = _mock_discovered_device(
-        id=int(mock_config_entry.unique_id), ip="10.0.0.40", name="net_ac_6888"
-    )
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "discover"}
     )
     assert result
 
+    # Create mock device for discovery
+    mock_device = MagicMock()
+    mock_device.id = int(mock_config_entry.unique_id)
+    mock_device.ip = "10.0.0.40"
+    mock_device.name = "net_ac_6888"
+    mock_device.type = DeviceType.AIR_CONDITIONER
+
     with patch(
         "custom_components.midea_ac.config_flow.Discover.discover",
         new_callable=AsyncMock,
-        return_value=[discovered]
+        return_value=[mock_device]
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -121,12 +112,21 @@ async def test_pick_device_flow_new_and_already_configured_devices(
     mock_config_entry: MockConfigEntry,
 ) -> None:
     """Test the discover flow only lists new devices when both new and already-configured devices are found."""
+    # Add config entry for existing device
     mock_config_entry.add_to_hass(hass)
 
-    already_configured = _mock_discovered_device(
-        id=int(mock_config_entry.unique_id), ip="10.0.0.40", name="net_ac_6888"
-    )
-    new_device = _mock_discovered_device(id=5678, ip="10.0.0.41", name="net_ac_1234")
+    # Create mock devices for discovery
+    mock_existing_device = MagicMock()
+    mock_existing_device.id = int(mock_config_entry.unique_id)
+    mock_existing_device.ip = "10.0.0.40"
+    mock_existing_device.name = "net_ac_6888"
+    mock_existing_device.type = DeviceType.AIR_CONDITIONER
+
+    mock_new_device = MagicMock()
+    mock_new_device.id = 5678
+    mock_new_device.ip = "10.0.0.41"
+    mock_new_device.name = "net_ac_1234"
+    mock_new_device.type = DeviceType.AIR_CONDITIONER
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "discover"}
@@ -136,7 +136,7 @@ async def test_pick_device_flow_new_and_already_configured_devices(
     with patch(
         "custom_components.midea_ac.config_flow.Discover.discover",
         new_callable=AsyncMock,
-        return_value=[already_configured, new_device]
+        return_value=[mock_existing_device, mock_new_device]
     ):
         result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
@@ -146,11 +146,12 @@ async def test_pick_device_flow_new_and_already_configured_devices(
     assert result["type"] is FlowResultType.FORM
     assert result["step_id"] == "pick_device"
 
-    # Only the new device should be selectable; the already-configured one
-    # is silently excluded, same as before this feature existed.
-    id_validator = next(v for k, v in result["data_schema"].schema.items()
-                         if k == CONF_ID)
-    assert list(id_validator.container.keys()) == [5678]
+    # Get the device ID passed to the form
+    device_ids = result["data_schema"].schema[CONF_ID].container.keys()
+
+    # Assert only the new device is present
+    assert mock_new_device.id in device_ids
+    assert mock_existing_device.id not in device_ids
 
 
 async def test_manual_flow_invalid_input(hass: HomeAssistant) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntryState
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType, InvalidData
+from msmart.const import DeviceType
 from msmart.device import AirConditioner as AC
 from msmart.lan import AuthenticationError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -46,6 +47,110 @@ async def test_config_flow_options(hass: HomeAssistant) -> None:
     assert manual_form_result["type"] is FlowResultType.FORM
     assert manual_form_result["step_id"] == "manual"
     assert not manual_form_result["errors"]
+
+
+def _mock_discovered_device(
+    id: int, ip: str, name: str,
+    device_type: DeviceType = DeviceType.AIR_CONDITIONER
+) -> MagicMock:
+    """Build a fake device as returned by Discover.discover()."""
+    device = MagicMock()
+    device.id = id
+    device.ip = ip
+    device.name = name
+    device.type = device_type
+    return device
+
+
+async def test_pick_device_flow_no_devices_found(hass: HomeAssistant) -> None:
+    """Test the discover flow aborts with no_devices_found when nothing is discovered."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "discover"}
+    )
+    assert result
+
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.discover",
+        new_callable=AsyncMock,
+        return_value=[]
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: ""}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"
+
+
+async def test_pick_device_flow_already_configured_devices_found(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the discover flow surfaces already-configured devices when no new device is found."""
+    mock_config_entry.add_to_hass(hass)
+
+    discovered = _mock_discovered_device(
+        id=int(mock_config_entry.unique_id), ip="10.0.0.40", name="net_ac_6888"
+    )
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "discover"}
+    )
+    assert result
+
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.discover",
+        new_callable=AsyncMock,
+        return_value=[discovered]
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: ""}
+        )
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured_devices_found"
+    assert result["description_placeholders"] == {
+        "devices": "- net_ac_6888 - 1234 (10.0.0.40)"
+    }
+
+
+async def test_pick_device_flow_new_and_already_configured_devices(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the discover flow only lists new devices when both new and already-configured devices are found."""
+    mock_config_entry.add_to_hass(hass)
+
+    already_configured = _mock_discovered_device(
+        id=int(mock_config_entry.unique_id), ip="10.0.0.40", name="net_ac_6888"
+    )
+    new_device = _mock_discovered_device(id=5678, ip="10.0.0.41", name="net_ac_1234")
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "discover"}
+    )
+    assert result
+
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.discover",
+        new_callable=AsyncMock,
+        return_value=[already_configured, new_device]
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: ""}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pick_device"
+
+    # Only the new device should be selectable; the already-configured one
+    # is silently excluded, same as before this feature existed.
+    id_validator = next(v for k, v in result["data_schema"].schema.items()
+                         if k == CONF_ID)
+    assert list(id_validator.container.keys()) == [5678]
 
 
 async def test_manual_flow_invalid_input(hass: HomeAssistant) -> None:


### PR DESCRIPTION
## Summary

- When the discover flow finds no *new* devices but some of the discovered devices are already configured in this Home Assistant instance, abort with a new `already_configured_devices_found` reason that lists them (name, ID, IP), instead of the generic "no devices found" message that gives no feedback either way.
- The plain "nothing found at all" case still uses the original `no_devices_found` message, unchanged.
- Localized across all 25 supported languages, following the same pattern as every other abort reason in this flow (a plain reason key mapped to a fully-translated string per locale file — no per-language logic in Python).

## Motivation

Full write-up, before/after screenshots, and discussion: #447

## Test plan

- [x] Verified locally against a real Home Assistant instance with one already-configured device: discovery with no new devices now lists the already-configured device instead of just "no devices found."
- [x] Verified the plain empty-network case still shows the original message.
- [x] Verified behavior when both new and already-configured devices are present: only new devices are shown (unchanged from previous behavior), no already-configured note.
- [x] All 25 translation files validated as well-formed JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
