### PR TITLE
Don't guess hvac_action direction in auto mode; add idle threshold for COOL/HEAT

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -32,6 +32,14 @@ from .coordinator import MideaCoordinatorEntity, MideaDeviceUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
 
+# Minimum overshoot past the setpoint, in degrees, before COOL/HEAT is
+# reported as actively running rather than idle. The device doesn't report
+# the real compressor state, so this is only an approximation - 0.5 matches
+# the sensor's smallest reporting step, avoiding flip-flopping between
+# COOLING/HEATING and IDLE on trivial fluctuations right at the setpoint.
+# TODO: make this configurable once there's a settings UI for it.
+_HVAC_ACTION_TEMPERATURE_THRESHOLD = 0.5
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -321,11 +329,19 @@ class MideaClimateDevice(MideaCoordinatorEntity[MideaDevice], ClimateEntity, Gen
         if current is None or target is None:
             return HVACAction.IDLE
 
-        if self.hvac_mode == HVACMode.COOL and current > target:
-            return HVACAction.COOLING
+        if self.hvac_mode == HVACMode.COOL:
+            return (
+                HVACAction.COOLING
+                if current > target + _HVAC_ACTION_TEMPERATURE_THRESHOLD
+                else HVACAction.IDLE
+            )
 
-        if self.hvac_mode == HVACMode.HEAT and current < target:
-            return HVACAction.HEATING
+        if self.hvac_mode == HVACMode.HEAT:
+            return (
+                HVACAction.HEATING
+                if current < target - _HVAC_ACTION_TEMPERATURE_THRESHOLD
+                else HVACAction.IDLE
+            )
 
         return HVACAction.IDLE
 

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -293,7 +293,7 @@ class MideaClimateDevice(MideaCoordinatorEntity[MideaDevice], ClimateEntity, Gen
         return self._OPERATIONAL_MODE_TO_HVAC_MODE.get(self._device.operational_mode, HVACMode.OFF)
 
     @property
-    def hvac_action(self) -> HVACAction:
+    def hvac_action(self) -> HVACAction | None:
         """Return the current HVAC action."""
 
         # For basic modes return the matching action
@@ -305,6 +305,15 @@ class MideaClimateDevice(MideaCoordinatorEntity[MideaDevice], ClimateEntity, Gen
         if (action := _HVAC_MODE_TO_HVAC_ACTION.get(self.hvac_mode)) != None:
             return action
 
+        # In auto mode the device doesn't report which direction it is
+        # actually operating in, so estimating from current vs. target
+        # temperature can be actively wrong (e.g. reporting "cooling" while
+        # the unit is heating past an overshoot). Report nothing rather than
+        # a potentially misleading value. See
+        # https://github.com/mill1000/midea-ac-py/issues/449
+        if self.hvac_mode == HVACMode.AUTO:
+            return None
+
         #  The device doesn't report actual activity, so we'll estimate the action based on sensors and set points
         current = self.current_temperature
         target = self.target_temperature
@@ -312,10 +321,10 @@ class MideaClimateDevice(MideaCoordinatorEntity[MideaDevice], ClimateEntity, Gen
         if current is None or target is None:
             return HVACAction.IDLE
 
-        if self.hvac_mode in [HVACMode.COOL, HVACMode.AUTO] and current > target:
+        if self.hvac_mode == HVACMode.COOL and current > target:
             return HVACAction.COOLING
 
-        if self.hvac_mode in [HVACMode.HEAT, HVACMode.AUTO] and current < target:
+        if self.hvac_mode == HVACMode.HEAT and current < target:
             return HVACAction.HEATING
 
         return HVACAction.IDLE

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -256,14 +256,14 @@ async def test_preset_modes(
         (True, AC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
         (True, AC.OperationalMode.HEAT, 24, 24, HVACAction.IDLE),
         (True, AC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
-        # Auto
-        (True, AC.OperationalMode.AUTO, 22, 24, HVACAction.HEATING),
-        (True, AC.OperationalMode.AUTO, 24, 24, HVACAction.IDLE),
-        (True, AC.OperationalMode.AUTO, 26, 24, HVACAction.COOLING),
+        # Auto - direction cannot be reliably determined locally, see #449
+        (True, AC.OperationalMode.AUTO, 22, 24, None),
+        (True, AC.OperationalMode.AUTO, 24, 24, None),
+        (True, AC.OperationalMode.AUTO, 26, 24, None),
         # No sensor input
         (True, AC.OperationalMode.HEAT, None, 24, HVACAction.IDLE),
         (True, AC.OperationalMode.COOL, None, 24, HVACAction.IDLE),
-        (True, AC.OperationalMode.AUTO, None, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.AUTO, None, 24, None),
     ],
 )
 async def test_ac_hvac_action(
@@ -272,7 +272,7 @@ async def test_ac_hvac_action(
     operational_mode: AC.OperationalMode,
     indoor_temperature: float | None,
     target_temperature: float,
-    expected_action: HVACAction,
+    expected_action: HVACAction | None,
 ):
     """Test hvac_action reflects the mode for the AC device."""
 
@@ -329,14 +329,14 @@ async def test_ac_hvac_action_defrosting(
         (True, CC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
         (True, CC.OperationalMode.HEAT, 24, 24, HVACAction.IDLE),
         (True, CC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
-        # Auto
-        (True, CC.OperationalMode.AUTO, 22, 24, HVACAction.HEATING),
-        (True, CC.OperationalMode.AUTO, 24, 24, HVACAction.IDLE),
-        (True, CC.OperationalMode.AUTO, 26, 24, HVACAction.COOLING),
+        # Auto - direction cannot be reliably determined locally, see #449
+        (True, CC.OperationalMode.AUTO, 22, 24, None),
+        (True, CC.OperationalMode.AUTO, 24, 24, None),
+        (True, CC.OperationalMode.AUTO, 26, 24, None),
         # No sensor input
         (True, CC.OperationalMode.HEAT, None, 24, HVACAction.IDLE),
         (True, CC.OperationalMode.COOL, None, 24, HVACAction.IDLE),
-        (True, CC.OperationalMode.AUTO, None, 24, HVACAction.IDLE),
+        (True, CC.OperationalMode.AUTO, None, 24, None),
     ],
 )
 async def test_cc_hvac_action(
@@ -345,7 +345,7 @@ async def test_cc_hvac_action(
     operational_mode: "CC.OperationalMode",
     indoor_temperature: float | None,
     target_temperature: float,
-    expected_action: HVACAction,
+    expected_action: HVACAction | None,
 ):
     """Test hvac_action reflects the mode for the CC device."""
 

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -252,10 +252,16 @@ async def test_preset_modes(
         (True, AC.OperationalMode.COOL, 26, 24, HVACAction.COOLING),
         (True, AC.OperationalMode.COOL, 24, 24, HVACAction.IDLE),
         (True, AC.OperationalMode.COOL, 22, 24, HVACAction.IDLE),
+        # Cool - within/at the idle threshold
+        (True, AC.OperationalMode.COOL, 24.5, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.COOL, 24.6, 24, HVACAction.COOLING),
         # Heat
         (True, AC.OperationalMode.HEAT, 22, 24, HVACAction.HEATING),
         (True, AC.OperationalMode.HEAT, 24, 24, HVACAction.IDLE),
         (True, AC.OperationalMode.HEAT, 26, 24, HVACAction.IDLE),
+        # Heat - within/at the idle threshold
+        (True, AC.OperationalMode.HEAT, 23.5, 24, HVACAction.IDLE),
+        (True, AC.OperationalMode.HEAT, 23.4, 24, HVACAction.HEATING),
         # Auto - direction cannot be reliably determined locally, see #449
         (True, AC.OperationalMode.AUTO, 22, 24, None),
         (True, AC.OperationalMode.AUTO, 24, 24, None),


### PR DESCRIPTION
## Summary

Follow-up to the `hvac_action` feature added in #444, addressing the problem raised in #449.

- In `AUTO` mode, `hvac_action` no longer guesses a direction (COOLING/HEATING) from current vs. target temperature. The local Midea protocol doesn't expose which direction the unit is actually operating in, and guessing from temperature alone can be actively wrong once the unit overshoots the setpoint - demonstrated in #449 with a real device: `auto` mode, `indoor_temperature=24.0` / `target_temperature=23.5`, unit actually heating, but the previous code reported `cooling`. `hvac_action` is now `None` in `auto` mode instead of a possibly-misleading value.
- For `COOL`/`HEAT` (where direction is unambiguous, since it's user-selected), simplified the branch logic now that it no longer needs to double as an `auto` filter, and added a 0.5°C threshold before switching from `IDLE` to `COOLING`/`HEATING`, to avoid flip-flopping right at the setpoint.

## Why

See the discussion in #449: the device doesn't report the real compressor/fan state, so any `hvac_action` value for a mode without an explicit user-selected direction is an approximation. We looked at how a number of other integrations handle this when they lack a real signal:

- HA core (Daikin, Mitsubishi Comfort, Honeywell, SmartThings, generic_thermostat, and fully-local ones like Shelly/KNX/Balboa/Flexit BACnet): all use a genuine device-reported signal (compressor frequency, standby flag, equipment/operating status, valve position, relay state, etc.) when available, and simply don't implement/return `hvac_action` when they don't have one (e.g. Broadlink, Modbus, ESPHome without the feature flag).
- HACS (Midea Auto Cloud): same pattern - real compressor/fan/direction signal when the device model exposes it, temperature-based approximation as a fallback otherwise.

Querying this device locally (`msmart-ng query --capabilities --energy`) confirms it doesn't expose compressor state, fan run state, or a resolved direction - so there's no real signal available to fall back to for `auto` mode direction on this protocol. Reporting nothing is more consistent with how the rest of the ecosystem handles this gap than continuing to guess.

## Testing

- Added/updated unit tests: `auto` mode now expects `None` regardless of temperature, plus new cases covering the threshold boundary on `COOL`/`HEAT`.
- Full suite passes locally (91 tests).

## Possible follow-ups (not included in this PR - open questions)

- **Make `hvac_action` disableable entirely**, via a config option, for anyone who'd rather have no value at all than an approximate one (this would also cover `COOL`/`HEAT`, not just `auto`). Open question: enabled or disabled by default?
- **Make the temperature threshold configurable** instead of the current hardcoded 0.5°C constant. Open question: a single shared threshold for both directions, or separate `cool_threshold`/`heat_threshold` values - overshoot behavior was reported as noticeably different between heat and cool on at least one device in #449.

Related to #449
