### PR TITLE
Fix _DEFAULT_OPTIONS mutation leaking AC options into other devices

### DIFF
--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -445,7 +445,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         }
 
         # Build default options based on device type
-        default_options = _DEFAULT_OPTIONS
+        default_options = dict(_DEFAULT_OPTIONS)
         if device.type == DeviceType.AIR_CONDITIONER:
             default_options |= _DEFAULT_AC_OPTIONS
 

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -445,9 +445,10 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         }
 
         # Build default options based on device type
-        default_options = dict(_DEFAULT_OPTIONS)
         if device.type == DeviceType.AIR_CONDITIONER:
-            default_options |= _DEFAULT_AC_OPTIONS
+            default_options = _DEFAULT_OPTIONS | _DEFAULT_AC_OPTIONS
+        else:
+            default_options = _DEFAULT_OPTIONS
 
         # Create a config entry with the config data and default options
         return self.async_create_entry(title=f"{DOMAIN} {device.id}", data=data, options=default_options)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -442,6 +442,77 @@ async def test_manual_flow_cc_device(hass: HomeAssistant) -> None:
         assert "errors" not in result
 
 
+async def test_ac_device_does_not_leak_default_options_into_later_cc_device(
+    hass: HomeAssistant,
+) -> None:
+    """Test that configuring an AC device doesn't affect the default
+    options given to a CC device configured afterward.
+
+    Regression test for #452: _create_entry_from_device used to alias
+    _DEFAULT_OPTIONS instead of copying it, so merging in
+    _DEFAULT_AC_OPTIONS for an AC device mutated the shared global in
+    place - leaking AC-only option keys into every device configured
+    afterward, regardless of its actual type.
+    """
+    # Configure an AC device first
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "manual"}
+    )
+    with (
+        patch("custom_components.midea_ac.async_setup_entry", return_value=True),
+        patch("custom_components.midea_ac.config_flow.AC.refresh"),
+        patch("custom_components.midea_ac.config_flow.AC.online",
+              new_callable=PropertyMock) as ac_online,
+        patch("custom_components.midea_ac.config_flow.AC.supported",
+              new_callable=PropertyMock) as ac_supported,
+    ):
+        ac_online.return_value = True
+        ac_supported.return_value = True
+        ac_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "localhost",
+                CONF_PORT: 6444,
+                CONF_ID: "1234",
+                CONF_DEVICE_TYPE: "AC",
+            },
+        )
+
+    assert ac_result["type"] is FlowResultType.CREATE_ENTRY
+    # Sanity check: the AC device correctly got its AC-specific options
+    assert CONF_BEEP in ac_result["result"].options
+
+    # Now configure an unrelated CC device
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "manual"}
+    )
+    with (
+        patch("custom_components.midea_ac.async_setup_entry", return_value=True),
+        patch("custom_components.midea_ac.config_flow.CC.refresh"),
+        patch("custom_components.midea_ac.config_flow.CC.online",
+              new_callable=PropertyMock) as cc_online,
+        patch("custom_components.midea_ac.config_flow.CC.supported",
+              new_callable=PropertyMock) as cc_supported,
+    ):
+        cc_online.return_value = True
+        cc_supported.return_value = True
+        cc_result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={
+                CONF_HOST: "localhost",
+                CONF_PORT: 6444,
+                CONF_ID: "5678",
+                CONF_DEVICE_TYPE: "CC",
+            },
+        )
+
+    assert cc_result["type"] is FlowResultType.CREATE_ENTRY
+
+    # CC's own option schema never exposes CONF_BEEP - it should never
+    # appear in a CC device's stored options.
+    assert CONF_BEEP not in cc_result["result"].options
+
+
 async def test_options_flow_init(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -14,8 +14,7 @@ from msmart.device import AirConditioner as AC
 from msmart.lan import AuthenticationError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.midea_ac.const import (CONF_BEEP, CONF_DEVICE_TYPE,
-                                              CONF_KEY, DOMAIN)
+from custom_components.midea_ac.const import *
 
 logging.basicConfig(level=logging.DEBUG)
 _LOGGER = logging.getLogger(__name__)
@@ -445,29 +444,23 @@ async def test_manual_flow_cc_device(hass: HomeAssistant) -> None:
 async def test_ac_device_does_not_leak_default_options_into_later_cc_device(
     hass: HomeAssistant,
 ) -> None:
-    """Test that configuring an AC device doesn't affect the default
-    options given to a CC device configured afterward.
+    """Test that configuring an AC device doesn't affect the default options given to a CC device configured afterward."""
 
-    Regression test for #452: _create_entry_from_device used to alias
-    _DEFAULT_OPTIONS instead of copying it, so merging in
-    _DEFAULT_AC_OPTIONS for an AC device mutated the shared global in
-    place - leaking AC-only option keys into every device configured
-    afterward, regardless of its actual type.
-    """
     # Configure an AC device first
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "manual"}
     )
+    assert result
+
     with (
         patch("custom_components.midea_ac.async_setup_entry", return_value=True),
         patch("custom_components.midea_ac.config_flow.AC.refresh"),
         patch("custom_components.midea_ac.config_flow.AC.online",
-              new_callable=PropertyMock) as ac_online,
+              new_callable=PropertyMock(return_value=True)),
         patch("custom_components.midea_ac.config_flow.AC.supported",
-              new_callable=PropertyMock) as ac_supported,
+              new_callable=PropertyMock(return_value=True)),
     ):
-        ac_online.return_value = True
-        ac_supported.return_value = True
+        # Configure device
         ac_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -479,23 +472,30 @@ async def test_ac_device_does_not_leak_default_options_into_later_cc_device(
         )
 
     assert ac_result["type"] is FlowResultType.CREATE_ENTRY
-    # Sanity check: the AC device correctly got its AC-specific options
-    assert CONF_BEEP in ac_result["result"].options
+
+    # Assert AC specific options are present
+    options = ac_result["result"].options
+    assert CONF_BEEP in options
+    assert CONF_FAN_SPEED_STEP in options
+    assert CONF_ENERGY_SENSOR in options
+    assert CONF_POWER_SENSOR in options
+    assert CONF_WORKAROUNDS in options
 
     # Now configure an unrelated CC device
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "manual"}
     )
+    assert result
+
     with (
         patch("custom_components.midea_ac.async_setup_entry", return_value=True),
         patch("custom_components.midea_ac.config_flow.CC.refresh"),
         patch("custom_components.midea_ac.config_flow.CC.online",
-              new_callable=PropertyMock) as cc_online,
+              new_callable=PropertyMock(return_value=True)),
         patch("custom_components.midea_ac.config_flow.CC.supported",
-              new_callable=PropertyMock) as cc_supported,
+              new_callable=PropertyMock(return_value=True)),
     ):
-        cc_online.return_value = True
-        cc_supported.return_value = True
+        # Configure device
         cc_result = await hass.config_entries.flow.async_configure(
             result["flow_id"],
             user_input={
@@ -508,9 +508,13 @@ async def test_ac_device_does_not_leak_default_options_into_later_cc_device(
 
     assert cc_result["type"] is FlowResultType.CREATE_ENTRY
 
-    # CC's own option schema never exposes CONF_BEEP - it should never
-    # appear in a CC device's stored options.
-    assert CONF_BEEP not in cc_result["result"].options
+    # Assert no AC options are present in CC device
+    options = cc_result["result"].options
+    assert CONF_BEEP not in options
+    assert CONF_FAN_SPEED_STEP not in options
+    assert CONF_ENERGY_SENSOR not in options
+    assert CONF_POWER_SENSOR not in options
+    assert CONF_WORKAROUNDS not in options
 
 
 async def test_options_flow_init(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -441,7 +441,7 @@ async def test_manual_flow_cc_device(hass: HomeAssistant) -> None:
         assert "errors" not in result
 
 
-async def test_ac_device_does_not_leak_default_options_into_later_cc_device(
+async def test_default_options_isolation(
     hass: HomeAssistant,
 ) -> None:
     """Test that configuring an AC device doesn't affect the default options given to a CC device configured afterward."""


### PR DESCRIPTION
## Summary

Fixes #452: configuring an AC device mutated the shared `_DEFAULT_OPTIONS` module-level dict in place, leaking AC-only option keys into every device configured afterward in the same running instance - including a CC device, whose own option schema (`_CC_OPTION_SCHEMA`) never exposes or uses them.

## Root cause

`_create_entry_from_device` did:

```python
default_options = _DEFAULT_OPTIONS
if device.type == DeviceType.AIR_CONDITIONER:
    default_options |= _DEFAULT_AC_OPTIONS
```

`default_options = _DEFAULT_OPTIONS` aliases the module-level dict rather than copying it. `|=` on a dict mutates in place, so this permanently merged `_DEFAULT_AC_OPTIONS` into the shared global the first time an AC device was configured - visible to every call afterward, regardless of device type.

## Fix

```python
default_options = dict(_DEFAULT_OPTIONS)
```

One-line change: copy before merging, so the mutation stays local to that call.

## Testing

- Added a regression test (`test_ac_device_does_not_leak_default_options_into_later_cc_device`) that configures an AC device then a CC device, and asserts the CC device's stored options never contain `CONF_BEEP` (an AC-only key). Fails on `main` without this fix, reproducing exactly what's described in #452.
- Full suite passes locally (88 tests).

Fixes #452
