### PR TITLE
Fix sensor platform setup when energy sensor options are missing

### DIFF
--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -64,10 +64,10 @@ async def async_setup_entry(
     # Only add energy sensors if device supports energy requests
     if hasattr(device, "enable_energy_usage_requests"):
         def _get_energy_config(key: str) -> tuple[EnergyFormat, float]:
-            config = config_entry.options.get(key)
+            config = config_entry.options.get(key) or {}
             format = device.EnergyDataFormat.get_from_name(
-                config.get(CONF_ENERGY_DATA_FORMAT).upper())
-            scale = config.get(CONF_ENERGY_DATA_SCALE)
+                config.get(CONF_ENERGY_DATA_FORMAT, EnergyFormat.BCD).upper())
+            scale = config.get(CONF_ENERGY_DATA_SCALE, 1.0)
             return format, scale
 
         # Configure energy format

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -4,9 +4,12 @@ from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import UnitOfEnergy, UnitOfPower
 from homeassistant.core import HomeAssistant
 from msmart.device import AirConditioner as AC
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.midea_ac.const import DOMAIN
 from custom_components.midea_ac.coordinator import MideaDeviceUpdateCoordinator
-from custom_components.midea_ac.sensor import MideaEnergySensor
+from custom_components.midea_ac.sensor import (MideaEnergySensor,
+                                               async_setup_entry)
 
 
 async def test_energy_sensor_request_enable(
@@ -58,5 +61,31 @@ async def test_energy_sensor_request_enable(
     await sensors[1].async_will_remove_from_hass()
     assert coordinator._energy_sensors == 0
     assert device.enable_energy_usage_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_setup_without_energy_options(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test the sensor platform sets up when energy options are missing."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create a config entry without energy sensor options
+    mock_config_entry.add_to_hass(hass)
+    hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = coordinator
+
+    entities = []
+
+    def add_entities(new_entities, update_before_add=False) -> None:
+        entities.extend(new_entities)
+
+    # Verify setup doesn't raise and energy sensors are created
+    await async_setup_entry(hass, mock_config_entry, add_entities)
+    assert any(isinstance(e, MideaEnergySensor) for e in entities)
 
     await coordinator.async_shutdown()


### PR DESCRIPTION
Fixes #459. When a config entry's options lack the energy_sensor/power_sensor keys, _get_energy_config crashed with AttributeError and took down the whole sensor platform, including the temperature sensors. Fall back to the default BCD format and 1.0 scale instead, with a regression test.