### PR TITLE
feat: support new group sensors and custom update interval

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -21,8 +21,9 @@ from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_CAPABILITY_OVERRIDES,
                     CONF_ENERGY_DATA_SCALE, CONF_ENERGY_SENSOR, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME,
                     CONF_MERGE_CAPABILITY_OVERRIDES, CONF_POWER_SENSOR,
-                    CONF_SHOW_ALL_PRESETS, CONF_USE_FAN_ONLY_WORKAROUND,
-                    CONF_WORKAROUNDS, DOMAIN, EnergyFormat)
+                    CONF_SHOW_ALL_PRESETS, CONF_UPDATE_INTERVAL,
+                    CONF_USE_FAN_ONLY_WORKAROUND, CONF_WORKAROUNDS, DOMAIN,
+                    UPDATE_INTERVAL, EnergyFormat)
 from .coordinator import MideaDeviceUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -95,7 +96,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 "Failed to apply capability overrides for device ID %s: %s", device.id, e)
 
     # Create device coordinator and fetch data
-    coordinator = MideaDeviceUpdateCoordinator(hass, device)  # type: ignore
+    poll_interval = config_entry.options.get(
+        CONF_UPDATE_INTERVAL, UPDATE_INTERVAL)
+    _LOGGER.info(
+        "Using update interval of %d seconds for device ID %s.", poll_interval, device.id)
+    coordinator = MideaDeviceUpdateCoordinator(
+        hass, device, update_interval=poll_interval)  # type: ignore
     await coordinator.async_config_entry_first_refresh()
 
     # Store coordinator in global data

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -211,6 +211,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             hass.config_entries.async_update_entry(
                 config_entry, options=new_options, minor_version=6)
 
+        # 1.6 -> 1.7: Add update interval option
+        if config_entry.minor_version == 6:
+            new_options = {**config_entry.options}
+            new_options.setdefault(CONF_UPDATE_INTERVAL, UPDATE_INTERVAL)
+
+            hass.config_entries.async_update_entry(
+                config_entry, options=new_options, minor_version=7)
+
     _LOGGER.debug("Migration to configuration version %s.%s successful.",
                   config_entry.version, config_entry.minor_version)
 

--- a/custom_components/midea_ac/binary_sensor.py
+++ b/custom_components/midea_ac/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import (MideaCoordinatorEntity, MideaDeviceUpdateCoordinator,
-                          MideaGroup5Entity)
+                          MideaGroup2Entity, MideaGroup5Entity)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +53,13 @@ async def async_setup_entry(
                                                 BinarySensorDeviceClass.RUNNING,
                                                 "defrost",
                                                 entity_category=EntityCategory.DIAGNOSTIC,
+                                                ))
+
+    if hasattr(device, "water_pump_running") and hasattr(device, "enable_group2_data_requests"):
+        entities.append(MideaGroup2BinarySensor(coordinator,
+                                                "water_pump_running",
+                                                BinarySensorDeviceClass.RUNNING,
+                                                "water_pump",
                                                 ))
     add_entities(entities)
 
@@ -119,4 +126,17 @@ class MideaGroup5BinarySensor(MideaBinarySensor, MideaGroup5Entity):
         MideaBinarySensor.__init__(self, *args, **kwargs)
 
         # Group5 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup2BinarySensor(MideaBinarySensor, MideaGroup2Entity):
+    """Binary sensor for Midea AC group 2 data (indoor unit)."""
+
+    def __init__(self,
+                 *args,
+                 **kwargs
+                 ) -> None:
+        MideaBinarySensor.__init__(self, *args, **kwargs)
+
+        # Group 2 sensors start disabled in case device doesn't support them
         self._attr_entity_registry_enabled_default = False

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -79,7 +79,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Midea Smart AC."""
 
     VERSION = 1
-    MINOR_VERSION = 6
+    MINOR_VERSION = 7
 
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle a config flow initialized by the user."""

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -38,8 +38,7 @@ from .const import (CONF_BEEP, CONF_CAPABILITY_OVERRIDES,
                     CONF_FAN_SPEED_STEP, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME,
                     CONF_MERGE_CAPABILITY_OVERRIDES, CONF_POWER_SENSOR,
-                    CONF_SWING_ANGLE_RTL, CONF_TEMP_STEP,
-                    CONF_UPDATE_INTERVAL,
+                    CONF_SWING_ANGLE_RTL, CONF_TEMP_STEP, CONF_UPDATE_INTERVAL,
                     CONF_USE_FAN_ONLY_WORKAROUND, CONF_WORKAROUNDS, DOMAIN,
                     UPDATE_INTERVAL, EnergyFormat)
 

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -39,12 +39,14 @@ from .const import (CONF_BEEP, CONF_CAPABILITY_OVERRIDES,
                     CONF_MAX_CONNECTION_LIFETIME,
                     CONF_MERGE_CAPABILITY_OVERRIDES, CONF_POWER_SENSOR,
                     CONF_SWING_ANGLE_RTL, CONF_TEMP_STEP,
+                    CONF_UPDATE_INTERVAL,
                     CONF_USE_FAN_ONLY_WORKAROUND, CONF_WORKAROUNDS, DOMAIN,
                     UPDATE_INTERVAL, EnergyFormat)
 
 _LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_OPTIONS = {
+    CONF_UPDATE_INTERVAL: UPDATE_INTERVAL,
     CONF_TEMP_STEP: 1.0,
     CONF_MAX_CONNECTION_LIFETIME: None,
     CONF_SWING_ANGLE_RTL: False,
@@ -465,6 +467,15 @@ class MideaOptionsFlow(OptionsFlow):
 
     _BASE_SCHEMA = vol.Schema(
         {
+            vol.Optional(CONF_UPDATE_INTERVAL): NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    max=30,
+                    step=1,
+                    unit_of_measurement="s",
+                    mode=NumberSelectorMode.SLIDER,
+                )
+            ),
             vol.Optional(CONF_SWING_ANGLE_RTL): cv.boolean,
             vol.Optional(CONF_TEMP_STEP): NumberSelector(
                 NumberSelectorConfig(

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -11,7 +11,7 @@ import yaml
 from homeassistant.config_entries import (ConfigEntry, ConfigFlow,
                                           ConfigFlowResult, OptionsFlow)
 from homeassistant.const import (CONF_COUNTRY_CODE, CONF_HOST, CONF_ID,
-                                 CONF_PORT, CONF_TOKEN, DEGREE)
+                                 CONF_PORT, CONF_TOKEN, DEGREE, UnitOfTime)
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers import httpx_client
@@ -471,7 +471,7 @@ class MideaOptionsFlow(OptionsFlow):
                     min=1,
                     max=30,
                     step=1,
-                    unit_of_measurement="s",
+                    unit_of_measurement=UnitOfTime.SECONDS,
                     mode=NumberSelectorMode.SLIDER,
                 )
             ),

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -6,6 +6,7 @@ from msmart.device import CommercialAirConditioner as CC
 
 DOMAIN = "midea_ac"
 UPDATE_INTERVAL = 15
+CONF_UPDATE_INTERVAL = "update_interval"
 
 CONF_KEY = "k1"
 CONF_BEEP = "prompt_tone"

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -3,7 +3,7 @@
 import datetime
 import logging
 from asyncio import Lock
-from typing import Any, Generic
+from typing import Generic
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
@@ -19,12 +19,13 @@ _LOGGER = logging.getLogger(__name__)
 class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
     """Device update coordinator for Midea Smart AC."""
 
-    def __init__(self, hass: HomeAssistant, device: MideaDevice) -> None:
+    def __init__(self, hass: HomeAssistant, device: MideaDevice,
+                 update_interval: int = UPDATE_INTERVAL) -> None:
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=datetime.timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=datetime.timedelta(seconds=update_interval),
             request_refresh_debouncer=Debouncer(
                 hass,
                 _LOGGER,
@@ -36,7 +37,11 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
         self._lock = Lock()
         self._proxy: MideaDeviceProxy[MideaDevice] = MideaDeviceProxy(device)
         self._energy_sensors = 0
+        self._group1_entities = 0
+        self._group2_entities = 0
         self._group5_entities = 0
+        self._group7_entities = 0
+        self._group11_entities = 0
 
     async def _async_update_data(self) -> None:
         """Update the device data."""
@@ -79,6 +84,36 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
         self._proxy.set_direct(
             "enable_energy_usage_requests", self._energy_sensors > 0)
 
+    def register_group1_entity(self) -> None:
+        """Record that a group1 data entity is active."""
+        if not hasattr(self._proxy, "enable_group1_data_requests"):
+            raise TypeError("Device does not support group 1 data.")
+        self._group1_entities += 1
+        self._proxy.set_direct("enable_group1_data_requests", True)
+
+    def unregister_group1_entity(self) -> None:
+        """Record that a group1 data entity is inactive."""
+        if not hasattr(self._proxy, "enable_group1_data_requests"):
+            raise TypeError("Device does not support group 1 data.")
+        self._group1_entities -= 1
+        self._proxy.set_direct(
+            "enable_group1_data_requests", self._group1_entities > 0)
+
+    def register_group2_entity(self) -> None:
+        """Record that a group2 data entity is active."""
+        if not hasattr(self._proxy, "enable_group2_data_requests"):
+            raise TypeError("Device does not support group 2 data.")
+        self._group2_entities += 1
+        self._proxy.set_direct("enable_group2_data_requests", True)
+
+    def unregister_group2_entity(self) -> None:
+        """Record that a group2 data entity is inactive."""
+        if not hasattr(self._proxy, "enable_group2_data_requests"):
+            raise TypeError("Device does not support group 2 data.")
+        self._group2_entities -= 1
+        self._proxy.set_direct(
+            "enable_group2_data_requests", self._group2_entities > 0)
+
     def register_group5_entity(self) -> None:
         """Record that a group5 data entity is active."""
 
@@ -101,6 +136,36 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
         # Disable requests if last entity
         self._proxy.set_direct(
             "enable_group5_data_requests", self._group5_entities > 0)
+
+    def register_group7_entity(self) -> None:
+        """Record that a group7 data entity is active."""
+        if not hasattr(self._proxy, "enable_group7_data_requests"):
+            raise TypeError("Device does not support group 7 data.")
+        self._group7_entities += 1
+        self._proxy.set_direct("enable_group7_data_requests", True)
+
+    def unregister_group7_entity(self) -> None:
+        """Record that a group7 data entity is inactive."""
+        if not hasattr(self._proxy, "enable_group7_data_requests"):
+            raise TypeError("Device does not support group 7 data.")
+        self._group7_entities -= 1
+        self._proxy.set_direct(
+            "enable_group7_data_requests", self._group7_entities > 0)
+
+    def register_group11_entity(self) -> None:
+        """Record that a group11 data entity is active."""
+        if not hasattr(self._proxy, "enable_group11_data_requests"):
+            raise TypeError("Device does not support group 11 data.")
+        self._group11_entities += 1
+        self._proxy.set_direct("enable_group11_data_requests", True)
+
+    def unregister_group11_entity(self) -> None:
+        """Record that a group11 data entity is inactive."""
+        if not hasattr(self._proxy, "enable_group11_data_requests"):
+            raise TypeError("Device does not support group 11 data.")
+        self._group11_entities -= 1
+        self._proxy.set_direct(
+            "enable_group11_data_requests", self._group11_entities > 0)
 
 
 class MideaCoordinatorEntity(CoordinatorEntity[MideaDeviceUpdateCoordinator], Generic[MideaDevice]):
@@ -136,3 +201,59 @@ class MideaGroup5Entity(MideaCoordinatorEntity):
 
         # Unregister group5 sensor with coordinator
         self.coordinator.unregister_group5_entity()
+
+
+class MideaGroup1Entity(MideaCoordinatorEntity):
+    """Entity that relies on Group 1 data (outdoor unit performance)."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.coordinator.register_group1_entity()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.unregister_group1_entity()
+
+
+class MideaGroup2Entity(MideaCoordinatorEntity):
+    """Entity that relies on Group 2 data (indoor fan data)."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.coordinator.register_group2_entity()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.unregister_group2_entity()
+
+
+class MideaGroup7Entity(MideaCoordinatorEntity):
+    """Entity that relies on Group 7 data (outdoor unit power)."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.coordinator.register_group7_entity()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.unregister_group7_entity()
+
+
+class MideaGroup11Entity(MideaCoordinatorEntity):
+    """Entity that relies on Group 11 data (louver angles)."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.coordinator.register_group11_entity()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.unregister_group11_entity()

--- a/custom_components/midea_ac/icons.json
+++ b/custom_components/midea_ac/icons.json
@@ -3,6 +3,9 @@
     "binary_sensor": {
       "self_clean": {
         "default": "mdi:spray-bottle"
+      },
+      "water_pump": {
+        "default": "mdi:water-pump"
       }
     },
     "climate": {
@@ -49,8 +52,47 @@
       }
     },
     "sensor": {
+      "compressor_current": {
+        "default": "mdi:current-ac"
+      },
+      "compressor_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "compressor_voltage": {
+        "default": "mdi:lightning-bolt"
+      },
+      "discharge_pipe_temperature": {
+        "default": "mdi:thermometer-high"
+      },
+      "horizontal_louvers_angle": {
+        "default": "mdi:angle-acute"
+      },
+      "indoor_coil_temperature": {
+        "default": "mdi:thermometer"
+      },
+      "indoor_fan_speed": {
+        "default": "mdi:fan"
+      },
+      "outdoor_coil_temperature": {
+        "default": "mdi:sun-thermometer"
+      },
+      "outdoor_fan_speed": {
+        "default": "mdi:fan"
+      },
       "outdoor_temperature": {
         "default": "mdi:sun-thermometer"
+      },
+      "outdoor_unit_power": {
+        "default": "mdi:lightning-bolt"
+      },
+      "target_compressor_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "target_indoor_fan_speed": {
+        "default": "mdi:fan"
+      },
+      "vertical_louvers_angle": {
+        "default": "mdi:angle-acute"
       }
     },
     "switch": {

--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -16,5 +16,5 @@
     "msmart-ng==2026.8.0",
     "pyyaml"
   ],
-  "version": "2026.7.2"
+  "version": "2026.8.0"
 }

--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -16,5 +16,5 @@
     "msmart-ng==2026.8.0",
     "pyyaml"
   ],
-  "version": "2026.8.0"
+  "version": "2026.7.2"
 }

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -130,13 +130,20 @@ async def async_setup_entry(
     # Group 1 — outdoor unit performance sensors
     if hasattr(device, "enable_group1_data_requests"):
         group1_sensors = [
-            ("target_compressor_frequency", SensorDeviceClass.FREQUENCY, UnitOfFrequency.HERTZ, "target_compressor_frequency"),
-            ("compressor_frequency", SensorDeviceClass.FREQUENCY, UnitOfFrequency.HERTZ, "compressor_frequency"),
-            ("compressor_current", SensorDeviceClass.CURRENT, UnitOfElectricCurrent.AMPERE, "compressor_current"),
-            ("compressor_voltage", SensorDeviceClass.VOLTAGE, UnitOfElectricPotential.VOLT, "compressor_voltage"),
-            ("indoor_coil_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "indoor_coil_temperature"),
-            ("outdoor_coil_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "outdoor_coil_temperature"),
-            ("discharge_pipe_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "discharge_pipe_temperature"),
+            ("target_compressor_frequency", SensorDeviceClass.FREQUENCY,
+             UnitOfFrequency.HERTZ, "target_compressor_frequency"),
+            ("compressor_frequency", SensorDeviceClass.FREQUENCY,
+             UnitOfFrequency.HERTZ, "compressor_frequency"),
+            ("compressor_current", SensorDeviceClass.CURRENT,
+             UnitOfElectricCurrent.AMPERE, "compressor_current"),
+            ("compressor_voltage", SensorDeviceClass.VOLTAGE,
+             UnitOfElectricPotential.VOLT, "compressor_voltage"),
+            ("indoor_coil_temperature", SensorDeviceClass.TEMPERATURE,
+             UnitOfTemperature.CELSIUS, "indoor_coil_temperature"),
+            ("outdoor_coil_temperature", SensorDeviceClass.TEMPERATURE,
+             UnitOfTemperature.CELSIUS, "outdoor_coil_temperature"),
+            ("discharge_pipe_temperature", SensorDeviceClass.TEMPERATURE,
+             UnitOfTemperature.CELSIUS, "discharge_pipe_temperature"),
         ]
         for prop, device_class, unit, translation_key in group1_sensors:
             if hasattr(device, prop):

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -6,7 +6,9 @@ import logging
 from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (PERCENTAGE, UnitOfEnergy, UnitOfPower,
+from homeassistant.const import (PERCENTAGE, UnitOfElectricCurrent,
+                                 UnitOfElectricPotential, UnitOfEnergy,
+                                 UnitOfFrequency, UnitOfPower,
                                  UnitOfTemperature)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -16,7 +18,9 @@ from .const import (CONF_ENERGY_DATA_FORMAT, CONF_ENERGY_DATA_SCALE,
                     CONF_ENERGY_SENSOR, CONF_POWER_SENSOR, DOMAIN,
                     EnergyFormat)
 from .coordinator import (MideaCoordinatorEntity, MideaDeviceUpdateCoordinator,
-                          MideaGroup5Entity)
+                          MideaGroup1Entity, MideaGroup2Entity,
+                          MideaGroup5Entity, MideaGroup7Entity,
+                          MideaGroup11Entity)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -119,9 +123,57 @@ async def async_setup_entry(
             coordinator,
             "outdoor_fan_speed",
             None,
-            None,
+            "rpm",
             "outdoor_fan_speed",
         ))
+
+    # Group 1 — outdoor unit performance sensors
+    if hasattr(device, "enable_group1_data_requests"):
+        group1_sensors = [
+            ("target_compressor_frequency", SensorDeviceClass.FREQUENCY, UnitOfFrequency.HERTZ, "target_compressor_frequency"),
+            ("compressor_frequency", SensorDeviceClass.FREQUENCY, UnitOfFrequency.HERTZ, "compressor_frequency"),
+            ("compressor_current", SensorDeviceClass.CURRENT, UnitOfElectricCurrent.AMPERE, "compressor_current"),
+            ("compressor_voltage", SensorDeviceClass.VOLTAGE, UnitOfElectricPotential.VOLT, "compressor_voltage"),
+            ("indoor_coil_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "indoor_coil_temperature"),
+            ("outdoor_coil_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "outdoor_coil_temperature"),
+            ("discharge_pipe_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "discharge_pipe_temperature"),
+        ]
+        for prop, device_class, unit, translation_key in group1_sensors:
+            if hasattr(device, prop):
+                entities.append(MideaGroup1Sensor(
+                    coordinator, prop, device_class, unit, translation_key))
+
+    # Group 2 — indoor fan sensors
+    if hasattr(device, "enable_group2_data_requests"):
+        group2_sensors = [
+            ("target_indoor_fan_speed", None, "rpm", "target_indoor_fan_speed"),
+            ("indoor_fan_speed", None, "rpm", "indoor_fan_speed"),
+        ]
+        for prop, device_class, unit, translation_key in group2_sensors:
+            if hasattr(device, prop):
+                entities.append(MideaGroup2Sensor(
+                    coordinator, prop, device_class, unit, translation_key))
+
+    # Group 7 — outdoor unit power sensor
+    if hasattr(device, "outdoor_unit_power") and hasattr(device, "enable_group7_data_requests"):
+        entities.append(MideaGroup7Sensor(
+            coordinator,
+            "outdoor_unit_power",
+            SensorDeviceClass.POWER,
+            UnitOfPower.WATT,
+            "outdoor_unit_power",
+        ))
+
+    # Group 11 — louver angle sensors
+    if hasattr(device, "enable_group11_data_requests"):
+        group11_sensors = [
+            ("horizontal_louvers_angle", None, None, "horizontal_louvers_angle"),
+            ("vertical_louvers_angle", None, None, "vertical_louvers_angle"),
+        ]
+        for prop, device_class, unit, translation_key in group11_sensors:
+            if hasattr(device, prop):
+                entities.append(MideaGroup11Sensor(
+                    coordinator, prop, device_class, unit, translation_key))
 
     add_entities(entities)
 
@@ -250,4 +302,44 @@ class MideaGroup5Sensor(MideaSensor, MideaGroup5Entity):
         MideaSensor.__init__(self, *args, **kwargs)
 
         # Group5 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup1Sensor(MideaSensor, MideaGroup1Entity):
+    """Sensor for Midea AC group 1 data (outdoor unit performance)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        MideaSensor.__init__(self, *args, **kwargs)
+
+        # Group 1 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup2Sensor(MideaSensor, MideaGroup2Entity):
+    """Sensor for Midea AC group 2 data (indoor fan)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        MideaSensor.__init__(self, *args, **kwargs)
+
+        # Group 2 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup7Sensor(MideaSensor, MideaGroup7Entity):
+    """Sensor for Midea AC group 7 data (outdoor unit power)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        MideaSensor.__init__(self, *args, **kwargs)
+
+        # Group 7 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup11Sensor(MideaSensor, MideaGroup11Entity):
+    """Sensor for Midea AC group 11 data (louver angles)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        MideaSensor.__init__(self, *args, **kwargs)
+
+        # Group 11 sensors start disabled in case device doesn't support them
         self._attr_entity_registry_enabled_default = False

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -154,7 +154,8 @@ async def async_setup_entry(
     # Group 2 — indoor fan sensors
     if hasattr(device, "enable_group2_data_requests"):
         group2_sensors = [
-            ("target_indoor_fan_speed", None, REVOLUTIONS_PER_MINUTE, "target_indoor_fan_speed"),
+            ("target_indoor_fan_speed", None,
+             REVOLUTIONS_PER_MINUTE, "target_indoor_fan_speed"),
             ("indoor_fan_speed", None, REVOLUTIONS_PER_MINUTE, "indoor_fan_speed"),
         ]
         for prop, device_class, unit, translation_key in group2_sensors:

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -6,7 +6,8 @@ import logging
 from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (PERCENTAGE, UnitOfElectricCurrent,
+from homeassistant.const import (DEGREE, PERCENTAGE, REVOLUTIONS_PER_MINUTE,
+                                 UnitOfElectricCurrent,
                                  UnitOfElectricPotential, UnitOfEnergy,
                                  UnitOfFrequency, UnitOfPower,
                                  UnitOfTemperature)
@@ -123,7 +124,7 @@ async def async_setup_entry(
             coordinator,
             "outdoor_fan_speed",
             None,
-            "rpm",
+            REVOLUTIONS_PER_MINUTE,
             "outdoor_fan_speed",
         ))
 
@@ -153,8 +154,8 @@ async def async_setup_entry(
     # Group 2 — indoor fan sensors
     if hasattr(device, "enable_group2_data_requests"):
         group2_sensors = [
-            ("target_indoor_fan_speed", None, "rpm", "target_indoor_fan_speed"),
-            ("indoor_fan_speed", None, "rpm", "indoor_fan_speed"),
+            ("target_indoor_fan_speed", None, REVOLUTIONS_PER_MINUTE, "target_indoor_fan_speed"),
+            ("indoor_fan_speed", None, REVOLUTIONS_PER_MINUTE, "indoor_fan_speed"),
         ]
         for prop, device_class, unit, translation_key in group2_sensors:
             if hasattr(device, prop):
@@ -174,8 +175,8 @@ async def async_setup_entry(
     # Group 11 — louver angle sensors
     if hasattr(device, "enable_group11_data_requests"):
         group11_sensors = [
-            ("horizontal_louvers_angle", None, None, "horizontal_louvers_angle"),
-            ("vertical_louvers_angle", None, None, "vertical_louvers_angle"),
+            ("horizontal_louvers_angle", None, DEGREE, "horizontal_louvers_angle"),
+            ("vertical_louvers_angle", None, DEGREE, "vertical_louvers_angle"),
         ]
         for prop, device_class, unit, translation_key in group11_sensors:
             if hasattr(device, prop):

--- a/custom_components/midea_ac/translations/de.json
+++ b/custom_components/midea_ac/translations/de.json
@@ -75,16 +75,22 @@
       "init": {
         "description": "Erweiterte Integrationseinstellungen.",
         "data": {
+          "update_interval": "Aktualisierungsintervall",
           "prompt_tone": "Signalton aktivieren",
           "temp_step": "Temperaturschritte",
           "fan_speed_step": "Lüftergeschwindigkeitsschritte",
           "max_connection_lifetime": "Maximale Verbindungsdauer",
-          "swing_angle_rtl": "Horizontalen Schwenkwinkel umkehren"
+          "swing_angle_rtl": "Horizontalen Schwenkwinkel umkehren",
+          "capability_overrides": "Capability-Overrides",
+          "merge_capability_overrides": "Overrides zusammenführen"
         },
         "data_description": {
+          "update_interval": "Wie oft das Gerät für Statusaktualisierungen abgefragt wird (1-30 Sekunden)",
           "temp_step": "Schrittgröße für Temperatureinstellung",
           "fan_speed_step": "Schrittgröße für Lüftergeschwindigkeit",
-          "max_connection_lifetime": "Maximale Zeit in Sekunden, die eine Verbindung verwendet wird (mindestens 15 Sekunden)"
+          "max_connection_lifetime": "Maximale Zeit in Sekunden, die eine Verbindung verwendet wird (mindestens 15 Sekunden)",
+          "capability_overrides": "Geräte-Capability-Overrides im YAML-Format",
+          "merge_capability_overrides": "Overrides mit vorhandenen Geräte-Capabilities zusammenführen"
         },
         "sections": {
           "energy_sensor": {
@@ -112,9 +118,7 @@
           "workarounds": {
             "name": "Workarounds",
             "data": {
-              "use_fan_only_workaround": "Nur-Lüfter-Workaround verwenden",
-              "show_all_presets": "Alle Voreinstellungen anzeigen",
-              "additional_operation_modes": "Zusätzliche Betriebsmodi"
+              "use_fan_only_workaround": "Nur-Lüfter-Workaround verwenden"
             },
             "data_description": {
               "additional_operation_modes": "Zusätzliche Betriebsmodi angeben"
@@ -122,6 +126,10 @@
           }
         }
       }
+    },
+    "error": {
+      "override_yaml_parse_error": "YAML konnte nicht geparst werden.",
+      "override_yaml_format_error": "Overrides müssen ein Dictionary sein."
     }
   },
   "selector": {
@@ -189,11 +197,22 @@
       },
       "self_clean": {
         "name": "Selbstreinigung"
+      },
+      "defrost": {
+        "name": "Abtauen"
+      },
+      "water_pump": {
+        "name": "Wasserpumpe"
       }
     },
     "button": {
       "self_clean": {
         "name": "Selbstreinigung starten"
+      }
+    },
+    "fan": {
+      "fresh_air": {
+        "name": "Frischluft"
       }
     },
     "number": {
@@ -282,8 +301,29 @@
       }
     },
     "sensor": {
+      "compressor_current": {
+        "name": "Kompressorstrom"
+      },
+      "compressor_frequency": {
+        "name": "Kompressorfrequenz"
+      },
+      "compressor_voltage": {
+        "name": "Kompressorspannung"
+      },
       "current_energy_usage": {
         "name": "Aktueller Energieverbrauch"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Druckrohrtemperatur"
+      },
+      "horizontal_louvers_angle": {
+        "name": "Horizontaler Lamellenwinkel"
+      },
+      "indoor_coil_temperature": {
+        "name": "Temperatur Wärmetauscher Innengerät"
+      },
+      "indoor_fan_speed": {
+        "name": "Lüfterdrehzahl Innengerät"
       },
       "indoor_humidity": {
         "name": "Luftfeuchtigkeit innen"
@@ -291,14 +331,32 @@
       "indoor_temperature": {
         "name": "Innentemperatur"
       },
+      "outdoor_coil_temperature": {
+        "name": "Temperatur Wärmetauscher Außengerät"
+      },
+      "outdoor_fan_speed": {
+        "name": "Lüfterdrehzahl Außengerät"
+      },
       "outdoor_temperature": {
         "name": "Außentemperatur"
+      },
+      "outdoor_unit_power": {
+        "name": "Leistung Außengerät"
       },
       "real_time_power_usage": {
         "name": "Leistungsaufnahme"
       },
+      "target_compressor_frequency": {
+        "name": "Ziel-Kompressorfrequenz"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Ziel-Lüfterdrehzahl Innengerät"
+      },
       "total_energy_usage": {
         "name": "Gesamtenergieverbrauch"
+      },
+      "vertical_louvers_angle": {
+        "name": "Vertikaler Lamellenwinkel"
       }
     },
     "switch": {

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -75,6 +75,7 @@
       "init": {
         "description": "Advanced integration settings.",
         "data": {
+          "update_interval": "Update Interval",
           "prompt_tone": "Enable Beep",
           "temp_step": "Temperature Step",
           "fan_speed_step": "Fan Speed Step",
@@ -84,6 +85,7 @@
           "merge_capability_overrides": "Merge Overrides"
         },
         "data_description": {
+          "update_interval": "How often to poll the device for state updates (1-30 seconds)",
           "temp_step": "Step size for temperature set point",
           "fan_speed_step": "Step size for custom fan speeds",
           "max_connection_lifetime": "Maximum time in seconds a connection will be used (15 second minimum)",
@@ -198,6 +200,9 @@
       },
       "defrost": {
         "name": "Defrost"
+      },
+      "water_pump": {
+        "name": "Water pump"
       }
     },
     "button": {
@@ -296,8 +301,29 @@
       }
     },
     "sensor": {
+      "compressor_current": {
+        "name": "Compressor current"
+      },
+      "compressor_frequency": {
+        "name": "Compressor frequency"
+      },
+      "compressor_voltage": {
+        "name": "Compressor voltage"
+      },
       "current_energy_usage": {
         "name": "Current energy"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Discharge pipe temperature"
+      },
+      "horizontal_louvers_angle": {
+        "name": "Horizontal louvers angle"
+      },
+      "indoor_coil_temperature": {
+        "name": "Indoor coil temperature"
+      },
+      "indoor_fan_speed": {
+        "name": "Indoor fan speed"
       },
       "indoor_humidity": {
         "name": "Indoor humidity"
@@ -305,17 +331,32 @@
       "indoor_temperature": {
         "name": "Indoor temperature"
       },
+      "outdoor_coil_temperature": {
+        "name": "Outdoor coil temperature"
+      },
       "outdoor_fan_speed": {
         "name": "Outdoor fan speed"
       },
       "outdoor_temperature": {
         "name": "Outdoor temperature"
       },
+      "outdoor_unit_power": {
+        "name": "Outdoor unit power"
+      },
       "real_time_power_usage": {
         "name": "Power"
       },
+      "target_compressor_frequency": {
+        "name": "Target compressor frequency"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Target indoor fan speed"
+      },
       "total_energy_usage": {
         "name": "Total energy"
+      },
+      "vertical_louvers_angle": {
+        "name": "Vertical louvers angle"
       }
     },
     "switch": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -545,7 +545,8 @@ async def test_options_flow_init(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
-                CONF_BEEP: False
+                CONF_BEEP: False,
+                CONF_UPDATE_INTERVAL: 20,
             },
         )
         await hass.async_block_till_done()
@@ -553,6 +554,7 @@ async def test_options_flow_init(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.options == {
         CONF_BEEP: False,
+        CONF_UPDATE_INTERVAL: 20,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,9 +10,18 @@ from homeassistant.core import HomeAssistant
 from msmart.device import AirConditioner as AC
 from msmart.lan import _LanProtocol
 
-from custom_components.midea_ac.binary_sensor import MideaGroup5BinarySensor
+from custom_components.midea_ac.binary_sensor import (
+    MideaGroup2BinarySensor,
+    MideaGroup5BinarySensor,
+)
 from custom_components.midea_ac.coordinator import MideaDeviceUpdateCoordinator
-from custom_components.midea_ac.sensor import MideaGroup5Sensor
+from custom_components.midea_ac.sensor import (
+    MideaGroup1Sensor,
+    MideaGroup2Sensor,
+    MideaGroup5Sensor,
+    MideaGroup7Sensor,
+    MideaGroup11Sensor,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -234,5 +243,160 @@ async def test_group5_entity_request_enable(
     await entities[1].async_will_remove_from_hass()
     assert coordinator._group5_entities == 0
     assert device.enable_group5_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_group1_entity_request_enable(
+    hass: HomeAssistant
+) -> None:
+    """Test AC device group1 entities enable requests when added to HA."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create entities
+    entities = [
+        MideaGroup1Sensor(
+            coordinator,
+            "outdoor_coil_temperature",
+            None,
+            None,
+            "outdoor_coil_temperature",
+        )
+    ]
+
+    # Add each sensor to HA
+    for entity in entities:
+        await entity.async_added_to_hass()
+
+    # Verify group 1 requests are enabled when entity is added to HA
+    assert coordinator._group1_entities == len(entities)
+    assert device.enable_group1_data_requests == True
+
+    # Remove 1 entity from HA
+    await entities[0].async_will_remove_from_hass()
+    assert coordinator._group1_entities == 0
+    assert device.enable_group1_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_group2_entity_request_enable(
+    hass: HomeAssistant
+) -> None:
+    """Test AC device group2 entities enable requests when added to HA."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create entities
+    entities = [
+        MideaGroup2Sensor(
+            coordinator,
+            "indoor_fan_speed",
+            None,
+            None,
+            "indoor_fan_speed",
+        ),
+        MideaGroup2BinarySensor(
+            coordinator,
+            "water_pump_running",
+            None,
+            "water_pump"
+        )
+    ]
+
+    # Add each sensor to HA
+    for entity in entities:
+        await entity.async_added_to_hass()
+
+    # Verify group 2 requests are enabled when entity is added to HA
+    assert coordinator._group2_entities == len(entities)
+    assert device.enable_group2_data_requests == True
+
+    # Remove 1 entity from HA
+    await entities[0].async_will_remove_from_hass()
+    assert coordinator._group2_entities == 1
+    assert device.enable_group2_data_requests == True
+
+    # Verify group 2 requests are disabled when last entity is removed
+    await entities[1].async_will_remove_from_hass()
+    assert coordinator._group2_entities == 0
+    assert device.enable_group2_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_group7_entity_request_enable(
+    hass: HomeAssistant
+) -> None:
+    """Test AC device group7 entities enable requests when added to HA."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create entities
+    entities = [
+        MideaGroup7Sensor(
+            coordinator,
+            "outdoor_unit_power",
+            None,
+            None,
+            "outdoor_unit_power",
+        )
+    ]
+
+    # Add each sensor to HA
+    for entity in entities:
+        await entity.async_added_to_hass()
+
+    # Verify group 7 requests are enabled when entity is added to HA
+    assert coordinator._group7_entities == len(entities)
+    assert device.enable_group7_data_requests == True
+
+    # Remove 1 entity from HA
+    await entities[0].async_will_remove_from_hass()
+    assert coordinator._group7_entities == 0
+    assert device.enable_group7_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_group11_entity_request_enable(
+    hass: HomeAssistant
+) -> None:
+    """Test AC device group11 entities enable requests when added to HA."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create entities
+    entities = [
+        MideaGroup11Sensor(
+            coordinator,
+            "horizontal_louvers_angle",
+            None,
+            None,
+            "horizontal_louvers_angle",
+        )
+    ]
+
+    # Add each sensor to HA
+    for entity in entities:
+        await entity.async_added_to_hass()
+
+    # Verify group 11 requests are enabled when entity is added to HA
+    assert coordinator._group11_entities == len(entities)
+    assert device.enable_group11_data_requests == True
+
+    # Remove 1 entity from HA
+    await entities[0].async_will_remove_from_hass()
+    assert coordinator._group11_entities == 0
+    assert device.enable_group11_data_requests == False
 
     await coordinator.async_shutdown()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,18 +10,14 @@ from homeassistant.core import HomeAssistant
 from msmart.device import AirConditioner as AC
 from msmart.lan import _LanProtocol
 
-from custom_components.midea_ac.binary_sensor import (
-    MideaGroup2BinarySensor,
-    MideaGroup5BinarySensor,
-)
+from custom_components.midea_ac.binary_sensor import (MideaGroup2BinarySensor,
+                                                      MideaGroup5BinarySensor)
 from custom_components.midea_ac.coordinator import MideaDeviceUpdateCoordinator
-from custom_components.midea_ac.sensor import (
-    MideaGroup1Sensor,
-    MideaGroup2Sensor,
-    MideaGroup5Sensor,
-    MideaGroup7Sensor,
-    MideaGroup11Sensor,
-)
+from custom_components.midea_ac.sensor import (MideaGroup1Sensor,
+                                               MideaGroup2Sensor,
+                                               MideaGroup5Sensor,
+                                               MideaGroup7Sensor,
+                                               MideaGroup11Sensor)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,9 +17,10 @@ from custom_components.midea_ac.const import (CONF_ADDITIONAL_OPERATION_MODES,
                                               CONF_ENERGY_SENSOR,
                                               CONF_POWER_SENSOR,
                                               CONF_SHOW_ALL_PRESETS,
+                                              CONF_UPDATE_INTERVAL,
                                               CONF_USE_FAN_ONLY_WORKAROUND,
                                               CONF_WORKAROUNDS, DOMAIN,
-                                              EnergyFormat)
+                                              UPDATE_INTERVAL, EnergyFormat)
 
 logging.basicConfig(level=logging.DEBUG)
 _LOGGER = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ async def test_config_entry_migration_from_5(hass: HomeAssistant) -> None:
 
     # Assert expected version
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
 
     # Grab options to test migration
     options = mock_config_entry.options
@@ -105,7 +106,7 @@ async def test_config_entry_migration_from_4(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
     assert mock_config_entry.data[CONF_DEVICE_TYPE] == DeviceType.AIR_CONDITIONER
 
 
@@ -135,7 +136,7 @@ async def test_config_entry_migration_from_3(hass: HomeAssistant) -> None:
 
     # Assert expected version
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
 
     # Grab options to test migration
     options = mock_config_entry.options
@@ -208,7 +209,7 @@ async def test_config_entry_migration_from_3_energy_formats(
 
     # Assert expected version
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
 
     # Grab options to test migration
     options = mock_config_entry.options
@@ -258,7 +259,7 @@ async def test_config_entry_migration_from_2(
 
     # Assert expected version
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
 
     # Grab options to test migration
     options = mock_config_entry.options
@@ -293,5 +294,36 @@ async def test_config_entry_migration_from_1(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
     assert isinstance(mock_config_entry.unique_id, str)
+
+
+async def test_config_entry_migration_from_6(hass: HomeAssistant) -> None:
+    """Test migration of config entry from 1.6"""
+
+    # Create a mock v1.6 config entry without update_interval
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        minor_version=6,
+        data={},
+        options={
+            CONF_CAPABILITY_OVERRIDES: "",
+        }
+    )
+
+    with patch(
+        "custom_components.midea_ac.async_setup_entry",
+        return_value=True,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.version == 1
+    assert mock_config_entry.minor_version == 7
+
+    # Verify update_interval was added with default value
+    options = mock_config_entry.options
+    assert CONF_UPDATE_INTERVAL in options
+    assert options[CONF_UPDATE_INTERVAL] == UPDATE_INTERVAL
+

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -326,4 +326,3 @@ async def test_config_entry_migration_from_6(hass: HomeAssistant) -> None:
     options = mock_config_entry.options
     assert CONF_UPDATE_INTERVAL in options
     assert options[CONF_UPDATE_INTERVAL] == UPDATE_INTERVAL
-


### PR DESCRIPTION
This PR brings the integration up to date with the latest `msmart-ng` release (`2026.8.0`) and exposes the newly available data points, alongside a polling configuration option.

### Key Changes
- **Dependency Update:** Upgraded `msmart-ng` requirement to `2026.8.0`.
- **New Group Sensors (Disabled by Default):** 
  - Exposed new group 1, 2, 7, and 11 properties (e.g., compressor frequency/voltage/current, coil temperatures, louver angles, indoor/outdoor fan speeds in RPM, and outdoor unit power).
  - Exposed the `water_pump_running` binary sensor (Group 2). 
  - All new entities are dynamically registered with the coordinator when enabled and disabled by default to avoid cluttering unsupported devices.
- **Customizable Update Interval:** Added an option in the integration's configuration flow (Options) to allow users to manually set the polling `update_interval` between 1 and 30 seconds.
- **Sensor Enhancements:** Properly assigned `"rpm"` as the unit of measurement for all fan speed sensors.
- **Testing:** Added comprehensive unit tests for the new coordinator registration logic and the new `update_interval` config flow.
