### PR TITLE
Guard current preset mode with reported device capabilities

### DIFF
--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -635,11 +635,11 @@ class MideaClimateCCDevice(MideaClimateDevice[CC]):
     @property
     def preset_mode(self) -> str:
         """Get the current preset mode."""
-        if self._device.eco:
+        if self._device.eco and self._device.supports_eco:
             return PRESET_ECO
-        elif self._device.silent:
+        elif self._device.silent and self._device.supports_silent:
             return PRESET_SILENT
-        elif self._device.sleep:
+        elif self._device.sleep and self._device.supports_sleeps:
             return PRESET_SLEEP
         else:
             return PRESET_NONE

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -544,13 +544,13 @@ class MideaClimateACDevice(MideaClimateDevice[AC]):
     @property
     def preset_mode(self) -> str:
         """Get the current preset mode."""
-        if self._device.eco:
+        if self._device.eco and self._device.supports_eco:
             return PRESET_ECO
-        elif self._device.ieco:
+        elif self._device.ieco and self._device.supports_ieco:
             return PRESET_IECO
-        elif self._device.turbo:
+        elif self._device.turbo and self._device.supports_turbo:
             return PRESET_BOOST
-        elif self._device.freeze_protection:
+        elif self._device.freeze_protection and self._device.supports_freeze_protection:
             return PRESET_AWAY
         elif self._device.sleep:
             return PRESET_SLEEP

--- a/custom_components/midea_ac/climate.py
+++ b/custom_components/midea_ac/climate.py
@@ -639,7 +639,7 @@ class MideaClimateCCDevice(MideaClimateDevice[CC]):
             return PRESET_ECO
         elif self._device.silent and self._device.supports_silent:
             return PRESET_SILENT
-        elif self._device.sleep and self._device.supports_sleeps:
+        elif self._device.sleep and self._device.supports_sleep:
             return PRESET_SLEEP
         else:
             return PRESET_NONE

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,11 +1,12 @@
 """Tests for the climate platform."""
 
 import logging
-from typing import Mapping
+from typing import List, Mapping
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from homeassistant.components.climate.const import (PRESET_ECO, PRESET_SLEEP,
+from homeassistant.components.climate.const import (PRESET_AWAY, PRESET_BOOST,
+                                                    PRESET_ECO, PRESET_SLEEP,
                                                     ClimateEntityFeature,
                                                     HVACMode)
 from homeassistant.core import HomeAssistant
@@ -17,6 +18,7 @@ from custom_components.midea_ac.climate import (ClimateConfig,
                                                 MideaClimateACDevice,
                                                 MideaClimateCCDevice,
                                                 MideaClimateDevice)
+from custom_components.midea_ac.const import PRESET_IECO, PRESET_SILENT
 
 logging.basicConfig(level=logging.DEBUG)
 _LOGGER = logging.getLogger(__name__)
@@ -236,3 +238,56 @@ async def test_preset_modes(
     # Assert configured modes are present
     for k, _ in config_modes.items():
         assert k in climate_device.preset_modes
+
+
+@pytest.mark.parametrize(
+    ("device_class", "config_modes"),
+    [
+        (AC, (PRESET_ECO, "eco", AC.Capability.ECO)),
+        (AC, (PRESET_IECO, "ieco", AC.Capability.IECO)),
+        (AC, (PRESET_BOOST, "turbo", AC.Capability.TURBO)),
+        (AC, (PRESET_AWAY, "freeze_protection", AC.Capability.FREEZE_PROTECTION)),
+        (CC, (PRESET_ECO, "eco", CC.Capability.ECO)),
+        (CC, (PRESET_SILENT, "silent", CC.Capability.SILENT)),
+        (CC, (PRESET_SLEEP, "sleep", CC.Capability.SLEEP)),
+
+    ],
+)
+async def test_preset_mode_requires_capability(
+    hass: HomeAssistant,
+    device_class: type[AC | CC],
+    config_modes: tuple[str, str, Flag],
+):
+    """Test preset mode is gated by support for that preset"""
+
+    # Mock the device
+    mock_device = device_class("0.0.0.0", 0, 0)
+
+    # Mock the coordinator
+    mock_coordinator = MagicMock()
+    mock_coordinator.apply = AsyncMock()
+    mock_coordinator.device = mock_device
+
+    # Create climate device with config
+    climate_device = None
+    if device_class == AC:
+        climate_device = MideaClimateACDevice(hass, mock_coordinator, {})
+    elif device_class == CC:
+        climate_device = MideaClimateCCDevice(hass, mock_coordinator, {})
+
+    preset, attr, capability = config_modes
+
+    for support in [True, False]:
+        # Enable/disable the capability for the target preset
+        mock_device._capabilities.set(capability, support)
+
+        # Assert device reports preset mode when active AND supported
+        setattr(mock_device, attr, True)
+        if support:
+            assert climate_device.preset_mode == preset
+        else:
+            assert climate_device.preset_mode != preset
+
+        # Assert device doesnt report preset mode when its inactive
+        setattr(mock_device, attr, False)
+        assert climate_device.preset_mode != preset

--- a/tests/test_climate.py
+++ b/tests/test_climate.py
@@ -1,12 +1,13 @@
 """Tests for the climate platform."""
 
 import logging
-from typing import List, Mapping
+from enum import Flag
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from homeassistant.components.climate.const import (PRESET_AWAY, PRESET_BOOST,
-                                                    PRESET_ECO, PRESET_SLEEP,
+                                                    PRESET_ECO, PRESET_NONE,
+                                                    PRESET_SLEEP,
                                                     ClimateEntityFeature,
                                                     HVACMode)
 from homeassistant.core import HomeAssistant
@@ -196,23 +197,29 @@ async def test_fan_speed_config(
 @pytest.mark.parametrize(
     ("device_class", "config_modes"),
     [
-        (AC, {}),
-        (AC, {PRESET_ECO: "_supports_eco"}),
-        (CC, {}),
-        (CC, {PRESET_SLEEP: "_supports_sleep"}),
+        (AC, (True, None, PRESET_NONE)),  # Always supported
+        (AC, (True, None, PRESET_SLEEP)),  # Always supported
+        (AC, (False, AC.Capability.ECO, PRESET_ECO)),  # Defaults to supported
+        (AC, (True, AC.Capability.IECO, PRESET_IECO)),
+        (CC, (True, None, PRESET_NONE)),  # Always supported
+        (CC, (False, CC.Capability.ECO, PRESET_ECO)),  # Defaults to supported
+        (CC, (False, CC.Capability.SLEEP, PRESET_SLEEP)),  # Defaults to supported
+
     ],
 )
 async def test_preset_modes(
     hass: HomeAssistant,
     device_class: type[AC | CC],
-    config_modes: Mapping[str, str],
+    config_modes: tuple[bool, Flag, str],
 ):
     """Test preset modes are properly configured"""
 
-    # Mock the device
+    support, capability, preset = config_modes
+
+    # Mock the device & it's capbilities
     mock_device = device_class("0.0.0.0", 0, 0)
-    for _, v in config_modes.items():
-        setattr(mock_device, v, True)
+    if capability:
+        mock_device._capabilities.set(capability, support)
 
     # Mock the coordinator
     mock_coordinator = MagicMock()
@@ -228,16 +235,17 @@ async def test_preset_modes(
 
     assert climate_device
 
-    # Assert feature flag is set if modes are present
-    if config_modes:
-        assert ClimateEntityFeature.PRESET_MODE & climate_device.supported_features
+    # Assert feature flag is set
+    assert ClimateEntityFeature.PRESET_MODE & climate_device.supported_features
 
     # Climate device should always have the property defined
     assert climate_device.preset_modes is not None
 
     # Assert configured modes are present
-    for k, _ in config_modes.items():
-        assert k in climate_device.preset_modes
+    if support:
+        assert preset in climate_device.preset_modes
+    else:
+        assert preset not in climate_device.preset_modes
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Some devices constantly report a preset mode they don't actually support, causing the UI to ignore all other presets

Many thanks to @willdood
Close #442 