### PR TITLE
Bump msmart-ng to 2026.8.0

### DIFF
--- a/custom_components/midea_ac/manifest.json
+++ b/custom_components/midea_ac/manifest.json
@@ -13,7 +13,7 @@
     "msmart"
   ],
   "requirements": [
-    "msmart-ng==2026.7.0",
+    "msmart-ng==2026.8.0",
     "pyyaml"
   ],
   "version": "2026.7.2"


### PR DESCRIPTION
# msmart-ng 2026.8.0

## What's Changed
* Add Group 1, 2 & 7 data queries / indoor & outdoor unit diagnostics by @its-tom in https://github.com/mill1000/midea-msmart/pull/278
* Add Group 11 response (louvers angles) support. by @TurboLed in https://github.com/mill1000/midea-msmart/pull/280
* Rename group 1 temperature outputs. Comment out redundant indoor temperature. by @TurboLed in https://github.com/mill1000/midea-msmart/pull/282