### PR TITLE
Remove stale cloud credentials in favor of using credentials from msmart-ng

### DIFF
--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -68,11 +68,6 @@ _DEFAULT_AC_OPTIONS = {
     }
 }
 
-_CLOUD_CREDENTIALS = {
-    "DE": ("midea_eu@mailinator.com", "das_ist_passwort1"),
-    "KR": ("midea_sea@mailinator.com", "password_for_sea1")
-}
-
 
 class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Midea Smart AC."""
@@ -100,17 +95,12 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
             if not (host := user_input.get(CONF_HOST)):
                 return await self.async_step_pick_device(country_code=country_code)
 
-            # Get credentials for region
-            account, password = _CLOUD_CREDENTIALS.get(
-                country_code, (None, None))
-
             # Attempt to find specified device
             device = await Discover.discover_single(
                 host,
                 auto_connect=False,
                 timeout=2,
-                account=account,
-                password=password,
+                region=country_code,
                 get_async_client=self._get_async_client
             )
 
@@ -119,21 +109,8 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
             elif device.type not in [DeviceType.AIR_CONDITIONER, DeviceType.COMMERCIAL_AC]:
                 errors["base"] = "unsupported_device"
             else:
-                # Check if device has already been configured
-                await self.async_set_unique_id(str(device.id))
-                self._abort_if_unique_id_configured()
-
-                # Finish connection
-                try:
-                    if await Discover.connect(device):
-                        assert isinstance(device, (AC, CC))
-                        return await self.async_step_show_token_key(device=device)
-                    else:
-                        # Indicate a connection could not be made
-                        return self.async_abort(reason="cannot_connect")
-                except CloudError:
-                    # Catch cloud errors and report to user
-                    return self.async_abort(reason="cloud_connection_failed")
+                # Attempt connection
+                return await self._attempt_auto_connection(device)
 
         data_schema = self.add_suggested_values_to_schema(
             vol.Schema({
@@ -161,41 +138,26 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
 
         if user_input is not None:
             # Find selected device
-            device = next(dev
-                          for dev in self._discovered_devices
-                          if dev.id == user_input[CONF_ID])
+            device = next(
+                dev
+                for dev in self._discovered_devices
+                if dev.id == user_input[CONF_ID]
+            )
 
             if device:
-                # Check if device has already been configured
-                await self.async_set_unique_id(str(device.id))
-                self._abort_if_unique_id_configured()
-
-                # Finish connection
-                try:
-                    if await Discover.connect(device):
-                        assert isinstance(device, (AC, CC))
-                        return await self.async_step_show_token_key(device=device)
-                    else:
-                        # Indicate a connection could not be made
-                        return self.async_abort(reason="cannot_connect")
-                except CloudError:
-                    # Catch cloud errors and report to user
-                    return self.async_abort(reason="cloud_connection_failed")
+                # Attempt connection
+                return await self._attempt_auto_connection(device)
 
         # Create a set of already configured devices by ID
         configured_devices = {
             entry.unique_id for entry in self._async_current_entries()
         }
 
-        # Get credentials for region
-        account, password = _CLOUD_CREDENTIALS.get(country_code, (None, None))
-
         # Discover all devices
         self._discovered_devices = await Discover.discover(
             auto_connect=False,
             timeout=2,
-            account=account,
-            password=password,
+            region=country_code,
             get_async_client=self._get_async_client
         )
 
@@ -429,6 +391,26 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
         await device.refresh()
 
         return device
+
+    async def _attempt_auto_connection(self, device: Device) -> ConfigFlowResult:
+        # Check if device has already been configured
+        await self.async_set_unique_id(str(device.id))
+        self._abort_if_unique_id_configured()
+
+        # Attempt connection
+        try:
+            success = await Discover.connect(device)
+        except CloudError:
+            # Catch cloud errors and report to user
+            return self.async_abort(reason="cloud_connection_failed")
+
+        if not success:
+            # Indicate a connection could not be made
+            return self.async_abort(reason="cannot_connect")
+
+        # On successful connection, display the token & key
+        assert isinstance(device, (AC, CC))
+        return await self.async_step_show_token_key(device=device)
 
     async def _create_entry_from_device(self, device) -> ConfigFlowResult:
         # Save the device into global data

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,11 @@
 """Pytest fixtures for testing Midea Smart AC."""
+from unittest.mock import MagicMock
+
 import pytest
 from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
 from homeassistant.core import HomeAssistant
+from msmart.const import DeviceType
+from msmart.device import AirConditioner as AC
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.midea_ac.const import CONF_DEVICE_TYPE, CONF_KEY, DOMAIN
@@ -27,3 +31,17 @@ def mock_config_entry(hass: HomeAssistant) -> MockConfigEntry:
             CONF_DEVICE_TYPE: 0xAC,
         }
     )
+
+
+@pytest.fixture
+def create_mock_device():
+    """Return a mock device factory."""
+    def _mock_device(device_id="1234", ip="10.0.0.40", name="net_ac_1234"):
+        device = MagicMock(spec=AC)
+        device.id = device_id
+        device.ip = ip
+        device.name = name
+        device.type = DeviceType.AIR_CONDITIONER
+        return device
+
+    return _mock_device

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -6,15 +6,24 @@ from unittest.mock import AsyncMock, MagicMock, PropertyMock, patch
 import pytest
 from homeassistant import config_entries
 from homeassistant.config_entries import ConfigEntryState
-from homeassistant.const import CONF_HOST, CONF_ID, CONF_PORT, CONF_TOKEN
+from homeassistant.const import (CONF_COUNTRY_CODE, CONF_HOST, CONF_ID,
+                                 CONF_PORT, CONF_TOKEN)
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType, InvalidData
+from msmart.cloud import CloudError, NetHomePlusCloud
 from msmart.const import DeviceType
 from msmart.device import AirConditioner as AC
 from msmart.lan import AuthenticationError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.midea_ac.const import *
+from custom_components.midea_ac.const import (CONF_BEEP,
+                                              CONF_CLOUD_COUNTRY_CODES,
+                                              CONF_DEFAULT_CLOUD_COUNTRY,
+                                              CONF_DEVICE_TYPE,
+                                              CONF_ENERGY_SENSOR,
+                                              CONF_FAN_SPEED_STEP, CONF_KEY,
+                                              CONF_POWER_SENSOR,
+                                              CONF_WORKAROUNDS, DOMAIN)
 
 logging.basicConfig(level=logging.DEBUG)
 _LOGGER = logging.getLogger(__name__)
@@ -48,7 +57,7 @@ async def test_config_flow_options(hass: HomeAssistant) -> None:
     assert not manual_form_result["errors"]
 
 
-async def test_pick_device_flow_no_devices_found(hass: HomeAssistant) -> None:
+async def test_discover_flow_no_devices_found(hass: HomeAssistant) -> None:
     """Test the discover flow aborts with no_devices_found when nothing is discovered."""
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "discover"}
@@ -69,9 +78,10 @@ async def test_pick_device_flow_no_devices_found(hass: HomeAssistant) -> None:
     assert result["reason"] == "no_devices_found"
 
 
-async def test_pick_device_flow_already_configured_devices_found(
+async def test_discover_flow_already_configured_devices_found(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    create_mock_device
 ) -> None:
     """Test the discover flow surfaces already-configured devices when no new device is found."""
     # Add config entry for existing device
@@ -83,11 +93,11 @@ async def test_pick_device_flow_already_configured_devices_found(
     assert result
 
     # Create mock device for discovery
-    mock_device = MagicMock()
-    mock_device.id = int(mock_config_entry.unique_id)
-    mock_device.ip = "10.0.0.40"
-    mock_device.name = "net_ac_6888"
-    mock_device.type = DeviceType.AIR_CONDITIONER
+    mock_device = create_mock_device(
+        int(mock_config_entry.unique_id),
+        "10.0.0.40",
+        "net_ac_6888",
+    )
 
     with patch(
         "custom_components.midea_ac.config_flow.Discover.discover",
@@ -106,26 +116,27 @@ async def test_pick_device_flow_already_configured_devices_found(
     }
 
 
-async def test_pick_device_flow_new_and_already_configured_devices(
+async def test_discover_flow_new_and_already_configured_devices(
     hass: HomeAssistant,
     mock_config_entry: MockConfigEntry,
+    create_mock_device
 ) -> None:
     """Test the discover flow only lists new devices when both new and already-configured devices are found."""
     # Add config entry for existing device
     mock_config_entry.add_to_hass(hass)
 
     # Create mock devices for discovery
-    mock_existing_device = MagicMock()
-    mock_existing_device.id = int(mock_config_entry.unique_id)
-    mock_existing_device.ip = "10.0.0.40"
-    mock_existing_device.name = "net_ac_6888"
-    mock_existing_device.type = DeviceType.AIR_CONDITIONER
+    mock_existing_device = create_mock_device(
+        int(mock_config_entry.unique_id),
+        "10.0.0.40",
+        "net_ac_6888"
+    )
 
-    mock_new_device = MagicMock()
-    mock_new_device.id = 5678
-    mock_new_device.ip = "10.0.0.41"
-    mock_new_device.name = "net_ac_1234"
-    mock_new_device.type = DeviceType.AIR_CONDITIONER
+    mock_new_device = create_mock_device(
+        5678,
+        "10.0.0.41",
+        "net_ac_1234"
+    )
 
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "discover"}
@@ -151,6 +162,160 @@ async def test_pick_device_flow_new_and_already_configured_devices(
     # Assert only the new device is present
     assert mock_new_device.id in device_ids
     assert mock_existing_device.id not in device_ids
+
+
+def test_cloud_country_codes_are_known_to_msmart() -> None:
+    """Test every selectable cloud region has credentials in msmart-ng.
+
+    The integration must not carry its own copy of the cloud credentials, so
+    the regions it offers have to be regions msmart-ng can actually log into.
+    """
+    assert set(CONF_CLOUD_COUNTRY_CODES) <= set(
+        NetHomePlusCloud.CLOUD_CREDENTIALS)
+    assert CONF_DEFAULT_CLOUD_COUNTRY in NetHomePlusCloud.CLOUD_CREDENTIALS
+
+
+@pytest.mark.parametrize(
+    "country_code",
+    CONF_CLOUD_COUNTRY_CODES
+)
+async def test_discover_flow_uses_selected_region(
+    hass: HomeAssistant,
+    country_code: str,
+) -> None:
+    """Test the selected country is passed to discovery as the cloud region."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "discover"}
+    )
+    assert result
+
+    # Check cloud region is passed to discover method
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.discover",
+        new_callable=AsyncMock,
+        return_value=[]
+    ) as mock_discover:
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: "", CONF_COUNTRY_CODE: country_code}
+        )
+
+    mock_discover.assert_awaited_once()
+    kwargs = mock_discover.await_args.kwargs
+
+    # Region must be forwarded so msmart-ng selects the right credentials
+    assert kwargs["region"] == country_code
+
+    # The integration must not supply its own credentials
+    assert "account" not in kwargs
+    assert "password" not in kwargs
+
+    # Restart flow
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "discover"}
+    )
+    assert result
+
+    # Check cloud region is passed to discover_single method
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.discover_single",
+        new_callable=AsyncMock,
+        return_value=None
+    ) as mock_discover_single:
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: "10.0.0.41",
+                        CONF_COUNTRY_CODE: country_code}
+        )
+
+    mock_discover_single.assert_awaited_once()
+    kwargs = mock_discover_single.await_args.kwargs
+
+    # Region must be forwarded so msmart-ng selects the right credentials
+    assert kwargs["region"] == country_code
+
+    # The integration must not supply its own credentials
+    assert "account" not in kwargs
+    assert "password" not in kwargs
+
+
+async def test_discover_flow_cloud_error(
+        hass: HomeAssistant,
+        create_mock_device
+) -> None:
+    """Test the discover flow aborts with cloud_connection_failed if a cloud exception is thrown."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "discover"}
+    )
+    assert result
+
+    mock_device = create_mock_device()
+
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.discover",
+        new_callable=AsyncMock,
+        return_value=[mock_device]
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: ""}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pick_device"
+
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.connect",
+        side_effect=CloudError(
+            "Failed to login to cloud. Code: 3102, Message: this account does not exist")
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ID: mock_device.id}
+        )
+
+    # Flow should abort with a reason
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cloud_connection_failed"
+
+
+async def test_discover_flow_cant_connect(
+        hass: HomeAssistant,
+        create_mock_device
+) -> None:
+    """Test the discover flow aborts with cannot_connect a device can't connect."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "discover"}
+    )
+    assert result
+
+    mock_device = create_mock_device()
+
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.discover",
+        new_callable=AsyncMock,
+        return_value=[mock_device]
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_HOST: ""}
+        )
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "pick_device"
+
+    with patch(
+        "custom_components.midea_ac.config_flow.Discover.connect",
+        return_value=False
+    ):
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            user_input={CONF_ID: mock_device.id}
+        )
+
+    # Connection should fail
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "cannot_connect"
 
 
 async def test_manual_flow_invalid_input(hass: HomeAssistant) -> None:

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -165,11 +165,7 @@ async def test_discover_flow_new_and_already_configured_devices(
 
 
 def test_cloud_country_codes_are_known_to_msmart() -> None:
-    """Test every selectable cloud region has credentials in msmart-ng.
-
-    The integration must not carry its own copy of the cloud credentials, so
-    the regions it offers have to be regions msmart-ng can actually log into.
-    """
+    """Test every selectable cloud region has credentials in msmart-ng."""
     assert set(CONF_CLOUD_COUNTRY_CODES) <= set(
         NetHomePlusCloud.CLOUD_CREDENTIALS)
     assert CONF_DEFAULT_CLOUD_COUNTRY in NetHomePlusCloud.CLOUD_CREDENTIALS


### PR DESCRIPTION
Pass cloud region through to msmart-ng instead of relying on stale credentials in the integration. The credentials haven't been valid for some time (maybe Mar 20, 2025).

- Add unit test to validate region is used
- Add unit tests for failing discovery connect

This partially supersedes the work done by @ansysic in PR #457, and @its-tom in PR #446. Both have highlighted some other improvements that could be made in follow-up PRs.

This, at least, should be enough to get those other regions working.