### PR TITLE
feat: Add configurable update interval option (1-30 seconds)

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -21,8 +21,9 @@ from .const import (CONF_ADDITIONAL_OPERATION_MODES, CONF_CAPABILITY_OVERRIDES,
                     CONF_ENERGY_DATA_SCALE, CONF_ENERGY_SENSOR, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME,
                     CONF_MERGE_CAPABILITY_OVERRIDES, CONF_POWER_SENSOR,
-                    CONF_SHOW_ALL_PRESETS, CONF_USE_FAN_ONLY_WORKAROUND,
-                    CONF_WORKAROUNDS, DOMAIN, EnergyFormat)
+                    CONF_SHOW_ALL_PRESETS, CONF_UPDATE_INTERVAL,
+                    CONF_USE_FAN_ONLY_WORKAROUND, CONF_WORKAROUNDS, DOMAIN,
+                    UPDATE_INTERVAL, EnergyFormat)
 from .coordinator import MideaDeviceUpdateCoordinator
 
 _LOGGER = logging.getLogger(__name__)
@@ -95,7 +96,12 @@ async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> b
                 "Failed to apply capability overrides for device ID %s: %s", device.id, e)
 
     # Create device coordinator and fetch data
-    coordinator = MideaDeviceUpdateCoordinator(hass, device)  # type: ignore
+    poll_interval = config_entry.options.get(
+        CONF_UPDATE_INTERVAL, UPDATE_INTERVAL)
+    _LOGGER.info(
+        "Using update interval of %d seconds for device ID %s.", poll_interval, device.id)
+    coordinator = MideaDeviceUpdateCoordinator(
+        hass, device, update_interval=poll_interval)  # type: ignore
     await coordinator.async_config_entry_first_refresh()
 
     # Store coordinator in global data

--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -211,6 +211,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
             hass.config_entries.async_update_entry(
                 config_entry, options=new_options, minor_version=6)
 
+        # 1.6 -> 1.7: Add update interval option
+        if config_entry.minor_version == 6:
+            new_options = {**config_entry.options}
+            new_options.setdefault(CONF_UPDATE_INTERVAL, UPDATE_INTERVAL)
+
+            hass.config_entries.async_update_entry(
+                config_entry, options=new_options, minor_version=7)
+
     _LOGGER.debug("Migration to configuration version %s.%s successful.",
                   config_entry.version, config_entry.minor_version)
 

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -38,8 +38,7 @@ from .const import (CONF_BEEP, CONF_CAPABILITY_OVERRIDES,
                     CONF_FAN_SPEED_STEP, CONF_KEY,
                     CONF_MAX_CONNECTION_LIFETIME,
                     CONF_MERGE_CAPABILITY_OVERRIDES, CONF_POWER_SENSOR,
-                    CONF_SWING_ANGLE_RTL, CONF_TEMP_STEP,
-                    CONF_UPDATE_INTERVAL,
+                    CONF_SWING_ANGLE_RTL, CONF_TEMP_STEP, CONF_UPDATE_INTERVAL,
                     CONF_USE_FAN_ONLY_WORKAROUND, CONF_WORKAROUNDS, DOMAIN,
                     UPDATE_INTERVAL, EnergyFormat)
 

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -74,7 +74,7 @@ class MideaConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Midea Smart AC."""
 
     VERSION = 1
-    MINOR_VERSION = 6
+    MINOR_VERSION = 7
 
     async def async_step_user(self, user_input=None) -> ConfigFlowResult:
         """Handle a config flow initialized by the user."""

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -11,7 +11,7 @@ import yaml
 from homeassistant.config_entries import (ConfigEntry, ConfigFlow,
                                           ConfigFlowResult, OptionsFlow)
 from homeassistant.const import (CONF_COUNTRY_CODE, CONF_HOST, CONF_ID,
-                                 CONF_PORT, CONF_TOKEN, DEGREE)
+                                 CONF_PORT, CONF_TOKEN, DEGREE, UnitOfTime)
 from homeassistant.core import callback
 from homeassistant.data_entry_flow import section
 from homeassistant.helpers import httpx_client
@@ -453,7 +453,7 @@ class MideaOptionsFlow(OptionsFlow):
                     min=1,
                     max=30,
                     step=1,
-                    unit_of_measurement="s",
+                    unit_of_measurement=UnitOfTime.SECONDS,
                     mode=NumberSelectorMode.SLIDER,
                 )
             ),

--- a/custom_components/midea_ac/config_flow.py
+++ b/custom_components/midea_ac/config_flow.py
@@ -39,12 +39,14 @@ from .const import (CONF_BEEP, CONF_CAPABILITY_OVERRIDES,
                     CONF_MAX_CONNECTION_LIFETIME,
                     CONF_MERGE_CAPABILITY_OVERRIDES, CONF_POWER_SENSOR,
                     CONF_SWING_ANGLE_RTL, CONF_TEMP_STEP,
+                    CONF_UPDATE_INTERVAL,
                     CONF_USE_FAN_ONLY_WORKAROUND, CONF_WORKAROUNDS, DOMAIN,
                     UPDATE_INTERVAL, EnergyFormat)
 
 _LOGGER = logging.getLogger(__name__)
 
 _DEFAULT_OPTIONS = {
+    CONF_UPDATE_INTERVAL: UPDATE_INTERVAL,
     CONF_TEMP_STEP: 1.0,
     CONF_MAX_CONNECTION_LIFETIME: None,
     CONF_SWING_ANGLE_RTL: False,
@@ -447,6 +449,15 @@ class MideaOptionsFlow(OptionsFlow):
 
     _BASE_SCHEMA = vol.Schema(
         {
+            vol.Optional(CONF_UPDATE_INTERVAL): NumberSelector(
+                NumberSelectorConfig(
+                    min=1,
+                    max=30,
+                    step=1,
+                    unit_of_measurement="s",
+                    mode=NumberSelectorMode.SLIDER,
+                )
+            ),
             vol.Optional(CONF_SWING_ANGLE_RTL): cv.boolean,
             vol.Optional(CONF_TEMP_STEP): NumberSelector(
                 NumberSelectorConfig(

--- a/custom_components/midea_ac/const.py
+++ b/custom_components/midea_ac/const.py
@@ -6,6 +6,7 @@ from msmart.device import CommercialAirConditioner as CC
 
 DOMAIN = "midea_ac"
 UPDATE_INTERVAL = 15
+CONF_UPDATE_INTERVAL = "update_interval"
 
 CONF_KEY = "k1"
 CONF_BEEP = "prompt_tone"

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -19,12 +19,13 @@ _LOGGER = logging.getLogger(__name__)
 class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
     """Device update coordinator for Midea Smart AC."""
 
-    def __init__(self, hass: HomeAssistant, device: MideaDevice) -> None:
+    def __init__(self, hass: HomeAssistant, device: MideaDevice,
+                 update_interval: int = UPDATE_INTERVAL) -> None:
         super().__init__(
             hass,
             _LOGGER,
             name=DOMAIN,
-            update_interval=datetime.timedelta(seconds=UPDATE_INTERVAL),
+            update_interval=datetime.timedelta(seconds=update_interval),
             request_refresh_debouncer=Debouncer(
                 hass,
                 _LOGGER,

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -75,6 +75,7 @@
       "init": {
         "description": "Advanced integration settings.",
         "data": {
+          "update_interval": "Update Interval",
           "prompt_tone": "Enable Beep",
           "temp_step": "Temperature Step",
           "fan_speed_step": "Fan Speed Step",
@@ -84,6 +85,7 @@
           "merge_capability_overrides": "Merge Overrides"
         },
         "data_description": {
+          "update_interval": "How often to poll the device for state updates (1-30 seconds)",
           "temp_step": "Step size for temperature set point",
           "fan_speed_step": "Step size for custom fan speeds",
           "max_connection_lifetime": "Maximum time in seconds a connection will be used (15 second minimum)",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -706,7 +706,8 @@ async def test_options_flow_init(
         result = await hass.config_entries.options.async_configure(
             result["flow_id"],
             user_input={
-                CONF_BEEP: False
+                CONF_BEEP: False,
+                CONF_UPDATE_INTERVAL: 20,
             },
         )
         await hass.async_block_till_done()
@@ -714,6 +715,7 @@ async def test_options_flow_init(
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert mock_config_entry.options == {
         CONF_BEEP: False,
+        CONF_UPDATE_INTERVAL: 20,
     }
     assert len(mock_setup_entry.mock_calls) == 1
 

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -16,14 +16,7 @@ from msmart.device import AirConditioner as AC
 from msmart.lan import AuthenticationError
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.midea_ac.const import (CONF_BEEP,
-                                              CONF_CLOUD_COUNTRY_CODES,
-                                              CONF_DEFAULT_CLOUD_COUNTRY,
-                                              CONF_DEVICE_TYPE,
-                                              CONF_ENERGY_SENSOR,
-                                              CONF_FAN_SPEED_STEP, CONF_KEY,
-                                              CONF_POWER_SENSOR,
-                                              CONF_WORKAROUNDS, DOMAIN)
+from custom_components.midea_ac.const import *
 
 logging.basicConfig(level=logging.DEBUG)
 _LOGGER = logging.getLogger(__name__)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -17,9 +17,10 @@ from custom_components.midea_ac.const import (CONF_ADDITIONAL_OPERATION_MODES,
                                               CONF_ENERGY_SENSOR,
                                               CONF_POWER_SENSOR,
                                               CONF_SHOW_ALL_PRESETS,
+                                              CONF_UPDATE_INTERVAL,
                                               CONF_USE_FAN_ONLY_WORKAROUND,
                                               CONF_WORKAROUNDS, DOMAIN,
-                                              EnergyFormat)
+                                              UPDATE_INTERVAL, EnergyFormat)
 
 logging.basicConfig(level=logging.DEBUG)
 _LOGGER = logging.getLogger(__name__)
@@ -67,7 +68,7 @@ async def test_config_entry_migration_from_5(hass: HomeAssistant) -> None:
 
     # Assert expected version
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
 
     # Grab options to test migration
     options = mock_config_entry.options
@@ -105,7 +106,7 @@ async def test_config_entry_migration_from_4(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
     assert mock_config_entry.data[CONF_DEVICE_TYPE] == DeviceType.AIR_CONDITIONER
 
 
@@ -135,7 +136,7 @@ async def test_config_entry_migration_from_3(hass: HomeAssistant) -> None:
 
     # Assert expected version
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
 
     # Grab options to test migration
     options = mock_config_entry.options
@@ -208,7 +209,7 @@ async def test_config_entry_migration_from_3_energy_formats(
 
     # Assert expected version
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
 
     # Grab options to test migration
     options = mock_config_entry.options
@@ -258,7 +259,7 @@ async def test_config_entry_migration_from_2(
 
     # Assert expected version
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
 
     # Grab options to test migration
     options = mock_config_entry.options
@@ -293,5 +294,36 @@ async def test_config_entry_migration_from_1(hass: HomeAssistant) -> None:
         await hass.async_block_till_done()
 
     assert mock_config_entry.version == 1
-    assert mock_config_entry.minor_version == 6
+    assert mock_config_entry.minor_version == 7
     assert isinstance(mock_config_entry.unique_id, str)
+
+
+async def test_config_entry_migration_from_6(hass: HomeAssistant) -> None:
+    """Test migration of config entry from 1.6"""
+
+    # Create a mock v1.6 config entry without update_interval
+    mock_config_entry = MockConfigEntry(
+        domain=DOMAIN,
+        minor_version=6,
+        data={},
+        options={
+            CONF_CAPABILITY_OVERRIDES: "",
+        }
+    )
+
+    with patch(
+        "custom_components.midea_ac.async_setup_entry",
+        return_value=True,
+    ):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.version == 1
+    assert mock_config_entry.minor_version == 7
+
+    # Verify update_interval was added with default value
+    options = mock_config_entry.options
+    assert CONF_UPDATE_INTERVAL in options
+    assert options[CONF_UPDATE_INTERVAL] == UPDATE_INTERVAL
+

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -326,4 +326,3 @@ async def test_config_entry_migration_from_6(hass: HomeAssistant) -> None:
     options = mock_config_entry.options
     assert CONF_UPDATE_INTERVAL in options
     assert options[CONF_UPDATE_INTERVAL] == UPDATE_INTERVAL
-


### PR DESCRIPTION
Split from #466. This PR adds a user-configurable polling interval to the integration options.

### Changes
- Adds a slider (1–30 seconds) in the options flow to configure the device update interval.
- Bumps the config minor version from 1.6 to 1.7 with a migration step that sets the default interval for existing entries.
- Uses `UnitOfTime.SECONDS` constant for the slider unit.
- Includes updated unit tests for the options flow and migration.
