### PR TITLE
feat: Add sensors for data groups 1, 2, 7, and 11

### DIFF
--- a/custom_components/midea_ac/binary_sensor.py
+++ b/custom_components/midea_ac/binary_sensor.py
@@ -12,7 +12,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import (MideaCoordinatorEntity, MideaDeviceUpdateCoordinator,
-                          MideaGroup5Entity)
+                          MideaGroup2Entity, MideaGroup5Entity)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -53,6 +53,13 @@ async def async_setup_entry(
                                                 BinarySensorDeviceClass.RUNNING,
                                                 "defrost",
                                                 entity_category=EntityCategory.DIAGNOSTIC,
+                                                ))
+
+    if hasattr(device, "water_pump_running") and hasattr(device, "enable_group2_data_requests"):
+        entities.append(MideaGroup2BinarySensor(coordinator,
+                                                "water_pump_running",
+                                                BinarySensorDeviceClass.RUNNING,
+                                                "water_pump",
                                                 ))
     add_entities(entities)
 
@@ -119,4 +126,17 @@ class MideaGroup5BinarySensor(MideaBinarySensor, MideaGroup5Entity):
         MideaBinarySensor.__init__(self, *args, **kwargs)
 
         # Group5 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup2BinarySensor(MideaBinarySensor, MideaGroup2Entity):
+    """Binary sensor for Midea AC group 2 data (indoor unit)."""
+
+    def __init__(self,
+                 *args,
+                 **kwargs
+                 ) -> None:
+        MideaBinarySensor.__init__(self, *args, **kwargs)
+
+        # Group 2 sensors start disabled in case device doesn't support them
         self._attr_entity_registry_enabled_default = False

--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -3,7 +3,7 @@
 import datetime
 import logging
 from asyncio import Lock
-from typing import Any, Generic
+from typing import Generic
 
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.debounce import Debouncer
@@ -36,7 +36,11 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
         self._lock = Lock()
         self._proxy: MideaDeviceProxy[MideaDevice] = MideaDeviceProxy(device)
         self._energy_sensors = 0
+        self._group1_entities = 0
+        self._group2_entities = 0
         self._group5_entities = 0
+        self._group7_entities = 0
+        self._group11_entities = 0
 
     async def _async_update_data(self) -> None:
         """Update the device data."""
@@ -79,6 +83,36 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
         self._proxy.set_direct(
             "enable_energy_usage_requests", self._energy_sensors > 0)
 
+    def register_group1_entity(self) -> None:
+        """Record that a group1 data entity is active."""
+        if not hasattr(self._proxy, "enable_group1_data_requests"):
+            raise TypeError("Device does not support group 1 data.")
+        self._group1_entities += 1
+        self._proxy.set_direct("enable_group1_data_requests", True)
+
+    def unregister_group1_entity(self) -> None:
+        """Record that a group1 data entity is inactive."""
+        if not hasattr(self._proxy, "enable_group1_data_requests"):
+            raise TypeError("Device does not support group 1 data.")
+        self._group1_entities -= 1
+        self._proxy.set_direct(
+            "enable_group1_data_requests", self._group1_entities > 0)
+
+    def register_group2_entity(self) -> None:
+        """Record that a group2 data entity is active."""
+        if not hasattr(self._proxy, "enable_group2_data_requests"):
+            raise TypeError("Device does not support group 2 data.")
+        self._group2_entities += 1
+        self._proxy.set_direct("enable_group2_data_requests", True)
+
+    def unregister_group2_entity(self) -> None:
+        """Record that a group2 data entity is inactive."""
+        if not hasattr(self._proxy, "enable_group2_data_requests"):
+            raise TypeError("Device does not support group 2 data.")
+        self._group2_entities -= 1
+        self._proxy.set_direct(
+            "enable_group2_data_requests", self._group2_entities > 0)
+
     def register_group5_entity(self) -> None:
         """Record that a group5 data entity is active."""
 
@@ -101,6 +135,36 @@ class MideaDeviceUpdateCoordinator(DataUpdateCoordinator, Generic[MideaDevice]):
         # Disable requests if last entity
         self._proxy.set_direct(
             "enable_group5_data_requests", self._group5_entities > 0)
+
+    def register_group7_entity(self) -> None:
+        """Record that a group7 data entity is active."""
+        if not hasattr(self._proxy, "enable_group7_data_requests"):
+            raise TypeError("Device does not support group 7 data.")
+        self._group7_entities += 1
+        self._proxy.set_direct("enable_group7_data_requests", True)
+
+    def unregister_group7_entity(self) -> None:
+        """Record that a group7 data entity is inactive."""
+        if not hasattr(self._proxy, "enable_group7_data_requests"):
+            raise TypeError("Device does not support group 7 data.")
+        self._group7_entities -= 1
+        self._proxy.set_direct(
+            "enable_group7_data_requests", self._group7_entities > 0)
+
+    def register_group11_entity(self) -> None:
+        """Record that a group11 data entity is active."""
+        if not hasattr(self._proxy, "enable_group11_data_requests"):
+            raise TypeError("Device does not support group 11 data.")
+        self._group11_entities += 1
+        self._proxy.set_direct("enable_group11_data_requests", True)
+
+    def unregister_group11_entity(self) -> None:
+        """Record that a group11 data entity is inactive."""
+        if not hasattr(self._proxy, "enable_group11_data_requests"):
+            raise TypeError("Device does not support group 11 data.")
+        self._group11_entities -= 1
+        self._proxy.set_direct(
+            "enable_group11_data_requests", self._group11_entities > 0)
 
 
 class MideaCoordinatorEntity(CoordinatorEntity[MideaDeviceUpdateCoordinator], Generic[MideaDevice]):
@@ -136,3 +200,59 @@ class MideaGroup5Entity(MideaCoordinatorEntity):
 
         # Unregister group5 sensor with coordinator
         self.coordinator.unregister_group5_entity()
+
+
+class MideaGroup1Entity(MideaCoordinatorEntity):
+    """Entity that relies on Group 1 data (outdoor unit performance)."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.coordinator.register_group1_entity()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.unregister_group1_entity()
+
+
+class MideaGroup2Entity(MideaCoordinatorEntity):
+    """Entity that relies on Group 2 data (indoor fan data)."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.coordinator.register_group2_entity()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.unregister_group2_entity()
+
+
+class MideaGroup7Entity(MideaCoordinatorEntity):
+    """Entity that relies on Group 7 data (outdoor unit power)."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.coordinator.register_group7_entity()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.unregister_group7_entity()
+
+
+class MideaGroup11Entity(MideaCoordinatorEntity):
+    """Entity that relies on Group 11 data (louver angles)."""
+
+    async def async_added_to_hass(self) -> None:
+        """Run when entity about to be added to hass."""
+        await super().async_added_to_hass()
+        self.coordinator.register_group11_entity()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Run when entity will be removed from hass."""
+        await super().async_will_remove_from_hass()
+        self.coordinator.unregister_group11_entity()

--- a/custom_components/midea_ac/icons.json
+++ b/custom_components/midea_ac/icons.json
@@ -3,6 +3,9 @@
     "binary_sensor": {
       "self_clean": {
         "default": "mdi:spray-bottle"
+      },
+      "water_pump": {
+        "default": "mdi:water-pump"
       }
     },
     "climate": {
@@ -49,8 +52,47 @@
       }
     },
     "sensor": {
+      "compressor_current": {
+        "default": "mdi:current-ac"
+      },
+      "compressor_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "compressor_voltage": {
+        "default": "mdi:lightning-bolt"
+      },
+      "discharge_pipe_temperature": {
+        "default": "mdi:thermometer-high"
+      },
+      "horizontal_louvers_angle": {
+        "default": "mdi:angle-acute"
+      },
+      "indoor_coil_temperature": {
+        "default": "mdi:thermometer"
+      },
+      "indoor_fan_speed": {
+        "default": "mdi:fan"
+      },
+      "outdoor_coil_temperature": {
+        "default": "mdi:sun-thermometer"
+      },
+      "outdoor_fan_speed": {
+        "default": "mdi:fan"
+      },
       "outdoor_temperature": {
         "default": "mdi:sun-thermometer"
+      },
+      "outdoor_unit_power": {
+        "default": "mdi:lightning-bolt"
+      },
+      "target_compressor_frequency": {
+        "default": "mdi:sine-wave"
+      },
+      "target_indoor_fan_speed": {
+        "default": "mdi:fan"
+      },
+      "vertical_louvers_angle": {
+        "default": "mdi:angle-acute"
       }
     },
     "switch": {

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -130,13 +130,20 @@ async def async_setup_entry(
     # Group 1 — outdoor unit performance sensors
     if hasattr(device, "enable_group1_data_requests"):
         group1_sensors = [
-            ("target_compressor_frequency", SensorDeviceClass.FREQUENCY, UnitOfFrequency.HERTZ, "target_compressor_frequency"),
-            ("compressor_frequency", SensorDeviceClass.FREQUENCY, UnitOfFrequency.HERTZ, "compressor_frequency"),
-            ("compressor_current", SensorDeviceClass.CURRENT, UnitOfElectricCurrent.AMPERE, "compressor_current"),
-            ("compressor_voltage", SensorDeviceClass.VOLTAGE, UnitOfElectricPotential.VOLT, "compressor_voltage"),
-            ("indoor_coil_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "indoor_coil_temperature"),
-            ("outdoor_coil_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "outdoor_coil_temperature"),
-            ("discharge_pipe_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "discharge_pipe_temperature"),
+            ("target_compressor_frequency", SensorDeviceClass.FREQUENCY,
+             UnitOfFrequency.HERTZ, "target_compressor_frequency"),
+            ("compressor_frequency", SensorDeviceClass.FREQUENCY,
+             UnitOfFrequency.HERTZ, "compressor_frequency"),
+            ("compressor_current", SensorDeviceClass.CURRENT,
+             UnitOfElectricCurrent.AMPERE, "compressor_current"),
+            ("compressor_voltage", SensorDeviceClass.VOLTAGE,
+             UnitOfElectricPotential.VOLT, "compressor_voltage"),
+            ("indoor_coil_temperature", SensorDeviceClass.TEMPERATURE,
+             UnitOfTemperature.CELSIUS, "indoor_coil_temperature"),
+            ("outdoor_coil_temperature", SensorDeviceClass.TEMPERATURE,
+             UnitOfTemperature.CELSIUS, "outdoor_coil_temperature"),
+            ("discharge_pipe_temperature", SensorDeviceClass.TEMPERATURE,
+             UnitOfTemperature.CELSIUS, "discharge_pipe_temperature"),
         ]
         for prop, device_class, unit, translation_key in group1_sensors:
             if hasattr(device, prop):

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -6,7 +6,9 @@ import logging
 from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (PERCENTAGE, UnitOfEnergy, UnitOfPower,
+from homeassistant.const import (PERCENTAGE, UnitOfElectricCurrent,
+                                 UnitOfElectricPotential, UnitOfEnergy,
+                                 UnitOfFrequency, UnitOfPower,
                                  UnitOfTemperature)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -16,7 +18,9 @@ from .const import (CONF_ENERGY_DATA_FORMAT, CONF_ENERGY_DATA_SCALE,
                     CONF_ENERGY_SENSOR, CONF_POWER_SENSOR, DOMAIN,
                     EnergyFormat)
 from .coordinator import (MideaCoordinatorEntity, MideaDeviceUpdateCoordinator,
-                          MideaGroup5Entity)
+                          MideaGroup1Entity, MideaGroup2Entity,
+                          MideaGroup5Entity, MideaGroup7Entity,
+                          MideaGroup11Entity)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -119,9 +123,57 @@ async def async_setup_entry(
             coordinator,
             "outdoor_fan_speed",
             None,
-            None,
+            "rpm",
             "outdoor_fan_speed",
         ))
+
+    # Group 1 — outdoor unit performance sensors
+    if hasattr(device, "enable_group1_data_requests"):
+        group1_sensors = [
+            ("target_compressor_frequency", SensorDeviceClass.FREQUENCY, UnitOfFrequency.HERTZ, "target_compressor_frequency"),
+            ("compressor_frequency", SensorDeviceClass.FREQUENCY, UnitOfFrequency.HERTZ, "compressor_frequency"),
+            ("compressor_current", SensorDeviceClass.CURRENT, UnitOfElectricCurrent.AMPERE, "compressor_current"),
+            ("compressor_voltage", SensorDeviceClass.VOLTAGE, UnitOfElectricPotential.VOLT, "compressor_voltage"),
+            ("indoor_coil_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "indoor_coil_temperature"),
+            ("outdoor_coil_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "outdoor_coil_temperature"),
+            ("discharge_pipe_temperature", SensorDeviceClass.TEMPERATURE, UnitOfTemperature.CELSIUS, "discharge_pipe_temperature"),
+        ]
+        for prop, device_class, unit, translation_key in group1_sensors:
+            if hasattr(device, prop):
+                entities.append(MideaGroup1Sensor(
+                    coordinator, prop, device_class, unit, translation_key))
+
+    # Group 2 — indoor fan sensors
+    if hasattr(device, "enable_group2_data_requests"):
+        group2_sensors = [
+            ("target_indoor_fan_speed", None, "rpm", "target_indoor_fan_speed"),
+            ("indoor_fan_speed", None, "rpm", "indoor_fan_speed"),
+        ]
+        for prop, device_class, unit, translation_key in group2_sensors:
+            if hasattr(device, prop):
+                entities.append(MideaGroup2Sensor(
+                    coordinator, prop, device_class, unit, translation_key))
+
+    # Group 7 — outdoor unit power sensor
+    if hasattr(device, "outdoor_unit_power") and hasattr(device, "enable_group7_data_requests"):
+        entities.append(MideaGroup7Sensor(
+            coordinator,
+            "outdoor_unit_power",
+            SensorDeviceClass.POWER,
+            UnitOfPower.WATT,
+            "outdoor_unit_power",
+        ))
+
+    # Group 11 — louver angle sensors
+    if hasattr(device, "enable_group11_data_requests"):
+        group11_sensors = [
+            ("horizontal_louvers_angle", None, None, "horizontal_louvers_angle"),
+            ("vertical_louvers_angle", None, None, "vertical_louvers_angle"),
+        ]
+        for prop, device_class, unit, translation_key in group11_sensors:
+            if hasattr(device, prop):
+                entities.append(MideaGroup11Sensor(
+                    coordinator, prop, device_class, unit, translation_key))
 
     add_entities(entities)
 
@@ -250,4 +302,44 @@ class MideaGroup5Sensor(MideaSensor, MideaGroup5Entity):
         MideaSensor.__init__(self, *args, **kwargs)
 
         # Group5 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup1Sensor(MideaSensor, MideaGroup1Entity):
+    """Sensor for Midea AC group 1 data (outdoor unit performance)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        MideaSensor.__init__(self, *args, **kwargs)
+
+        # Group 1 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup2Sensor(MideaSensor, MideaGroup2Entity):
+    """Sensor for Midea AC group 2 data (indoor fan)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        MideaSensor.__init__(self, *args, **kwargs)
+
+        # Group 2 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup7Sensor(MideaSensor, MideaGroup7Entity):
+    """Sensor for Midea AC group 7 data (outdoor unit power)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        MideaSensor.__init__(self, *args, **kwargs)
+
+        # Group 7 sensors start disabled in case device doesn't support them
+        self._attr_entity_registry_enabled_default = False
+
+
+class MideaGroup11Sensor(MideaSensor, MideaGroup11Entity):
+    """Sensor for Midea AC group 11 data (louver angles)."""
+
+    def __init__(self, *args, **kwargs) -> None:
+        MideaSensor.__init__(self, *args, **kwargs)
+
+        # Group 11 sensors start disabled in case device doesn't support them
         self._attr_entity_registry_enabled_default = False

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -154,7 +154,8 @@ async def async_setup_entry(
     # Group 2 — indoor fan sensors
     if hasattr(device, "enable_group2_data_requests"):
         group2_sensors = [
-            ("target_indoor_fan_speed", None, REVOLUTIONS_PER_MINUTE, "target_indoor_fan_speed"),
+            ("target_indoor_fan_speed", None,
+             REVOLUTIONS_PER_MINUTE, "target_indoor_fan_speed"),
             ("indoor_fan_speed", None, REVOLUTIONS_PER_MINUTE, "indoor_fan_speed"),
         ]
         for prop, device_class, unit, translation_key in group2_sensors:

--- a/custom_components/midea_ac/sensor.py
+++ b/custom_components/midea_ac/sensor.py
@@ -6,7 +6,8 @@ import logging
 from homeassistant.components.sensor import (SensorDeviceClass, SensorEntity,
                                              SensorStateClass)
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (PERCENTAGE, UnitOfElectricCurrent,
+from homeassistant.const import (DEGREE, PERCENTAGE, REVOLUTIONS_PER_MINUTE,
+                                 UnitOfElectricCurrent,
                                  UnitOfElectricPotential, UnitOfEnergy,
                                  UnitOfFrequency, UnitOfPower,
                                  UnitOfTemperature)
@@ -123,7 +124,7 @@ async def async_setup_entry(
             coordinator,
             "outdoor_fan_speed",
             None,
-            "rpm",
+            REVOLUTIONS_PER_MINUTE,
             "outdoor_fan_speed",
         ))
 
@@ -153,8 +154,8 @@ async def async_setup_entry(
     # Group 2 — indoor fan sensors
     if hasattr(device, "enable_group2_data_requests"):
         group2_sensors = [
-            ("target_indoor_fan_speed", None, "rpm", "target_indoor_fan_speed"),
-            ("indoor_fan_speed", None, "rpm", "indoor_fan_speed"),
+            ("target_indoor_fan_speed", None, REVOLUTIONS_PER_MINUTE, "target_indoor_fan_speed"),
+            ("indoor_fan_speed", None, REVOLUTIONS_PER_MINUTE, "indoor_fan_speed"),
         ]
         for prop, device_class, unit, translation_key in group2_sensors:
             if hasattr(device, prop):
@@ -174,8 +175,8 @@ async def async_setup_entry(
     # Group 11 — louver angle sensors
     if hasattr(device, "enable_group11_data_requests"):
         group11_sensors = [
-            ("horizontal_louvers_angle", None, None, "horizontal_louvers_angle"),
-            ("vertical_louvers_angle", None, None, "vertical_louvers_angle"),
+            ("horizontal_louvers_angle", None, DEGREE, "horizontal_louvers_angle"),
+            ("vertical_louvers_angle", None, DEGREE, "vertical_louvers_angle"),
         ]
         for prop, device_class, unit, translation_key in group11_sensors:
             if hasattr(device, prop):

--- a/custom_components/midea_ac/translations/en.json
+++ b/custom_components/midea_ac/translations/en.json
@@ -198,6 +198,9 @@
       },
       "defrost": {
         "name": "Defrost"
+      },
+      "water_pump": {
+        "name": "Water pump"
       }
     },
     "button": {
@@ -296,8 +299,29 @@
       }
     },
     "sensor": {
+      "compressor_current": {
+        "name": "Compressor current"
+      },
+      "compressor_frequency": {
+        "name": "Compressor frequency"
+      },
+      "compressor_voltage": {
+        "name": "Compressor voltage"
+      },
       "current_energy_usage": {
         "name": "Current energy"
+      },
+      "discharge_pipe_temperature": {
+        "name": "Discharge pipe temperature"
+      },
+      "horizontal_louvers_angle": {
+        "name": "Horizontal louvers angle"
+      },
+      "indoor_coil_temperature": {
+        "name": "Indoor coil temperature"
+      },
+      "indoor_fan_speed": {
+        "name": "Indoor fan speed"
       },
       "indoor_humidity": {
         "name": "Indoor humidity"
@@ -305,17 +329,32 @@
       "indoor_temperature": {
         "name": "Indoor temperature"
       },
+      "outdoor_coil_temperature": {
+        "name": "Outdoor coil temperature"
+      },
       "outdoor_fan_speed": {
         "name": "Outdoor fan speed"
       },
       "outdoor_temperature": {
         "name": "Outdoor temperature"
       },
+      "outdoor_unit_power": {
+        "name": "Outdoor unit power"
+      },
       "real_time_power_usage": {
         "name": "Power"
       },
+      "target_compressor_frequency": {
+        "name": "Target compressor frequency"
+      },
+      "target_indoor_fan_speed": {
+        "name": "Target indoor fan speed"
+      },
       "total_energy_usage": {
         "name": "Total energy"
+      },
+      "vertical_louvers_angle": {
+        "name": "Vertical louvers angle"
       }
     },
     "switch": {

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,9 +10,18 @@ from homeassistant.core import HomeAssistant
 from msmart.device import AirConditioner as AC
 from msmart.lan import _LanProtocol
 
-from custom_components.midea_ac.binary_sensor import MideaGroup5BinarySensor
+from custom_components.midea_ac.binary_sensor import (
+    MideaGroup2BinarySensor,
+    MideaGroup5BinarySensor,
+)
 from custom_components.midea_ac.coordinator import MideaDeviceUpdateCoordinator
-from custom_components.midea_ac.sensor import MideaGroup5Sensor
+from custom_components.midea_ac.sensor import (
+    MideaGroup1Sensor,
+    MideaGroup2Sensor,
+    MideaGroup5Sensor,
+    MideaGroup7Sensor,
+    MideaGroup11Sensor,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -234,5 +243,160 @@ async def test_group5_entity_request_enable(
     await entities[1].async_will_remove_from_hass()
     assert coordinator._group5_entities == 0
     assert device.enable_group5_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_group1_entity_request_enable(
+    hass: HomeAssistant
+) -> None:
+    """Test AC device group1 entities enable requests when added to HA."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create entities
+    entities = [
+        MideaGroup1Sensor(
+            coordinator,
+            "outdoor_coil_temperature",
+            None,
+            None,
+            "outdoor_coil_temperature",
+        )
+    ]
+
+    # Add each sensor to HA
+    for entity in entities:
+        await entity.async_added_to_hass()
+
+    # Verify group 1 requests are enabled when entity is added to HA
+    assert coordinator._group1_entities == len(entities)
+    assert device.enable_group1_data_requests == True
+
+    # Remove 1 entity from HA
+    await entities[0].async_will_remove_from_hass()
+    assert coordinator._group1_entities == 0
+    assert device.enable_group1_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_group2_entity_request_enable(
+    hass: HomeAssistant
+) -> None:
+    """Test AC device group2 entities enable requests when added to HA."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create entities
+    entities = [
+        MideaGroup2Sensor(
+            coordinator,
+            "indoor_fan_speed",
+            None,
+            None,
+            "indoor_fan_speed",
+        ),
+        MideaGroup2BinarySensor(
+            coordinator,
+            "water_pump_running",
+            None,
+            "water_pump"
+        )
+    ]
+
+    # Add each sensor to HA
+    for entity in entities:
+        await entity.async_added_to_hass()
+
+    # Verify group 2 requests are enabled when entity is added to HA
+    assert coordinator._group2_entities == len(entities)
+    assert device.enable_group2_data_requests == True
+
+    # Remove 1 entity from HA
+    await entities[0].async_will_remove_from_hass()
+    assert coordinator._group2_entities == 1
+    assert device.enable_group2_data_requests == True
+
+    # Verify group 2 requests are disabled when last entity is removed
+    await entities[1].async_will_remove_from_hass()
+    assert coordinator._group2_entities == 0
+    assert device.enable_group2_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_group7_entity_request_enable(
+    hass: HomeAssistant
+) -> None:
+    """Test AC device group7 entities enable requests when added to HA."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create entities
+    entities = [
+        MideaGroup7Sensor(
+            coordinator,
+            "outdoor_unit_power",
+            None,
+            None,
+            "outdoor_unit_power",
+        )
+    ]
+
+    # Add each sensor to HA
+    for entity in entities:
+        await entity.async_added_to_hass()
+
+    # Verify group 7 requests are enabled when entity is added to HA
+    assert coordinator._group7_entities == len(entities)
+    assert device.enable_group7_data_requests == True
+
+    # Remove 1 entity from HA
+    await entities[0].async_will_remove_from_hass()
+    assert coordinator._group7_entities == 0
+    assert device.enable_group7_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_group11_entity_request_enable(
+    hass: HomeAssistant
+) -> None:
+    """Test AC device group11 entities enable requests when added to HA."""
+
+    # Create a dummy device and coordinator
+    device = AC("0.0.0.0", 0, 0)
+    coordinator = MideaDeviceUpdateCoordinator(hass, device)
+
+    # Create entities
+    entities = [
+        MideaGroup11Sensor(
+            coordinator,
+            "horizontal_louvers_angle",
+            None,
+            None,
+            "horizontal_louvers_angle",
+        )
+    ]
+
+    # Add each sensor to HA
+    for entity in entities:
+        await entity.async_added_to_hass()
+
+    # Verify group 11 requests are enabled when entity is added to HA
+    assert coordinator._group11_entities == len(entities)
+    assert device.enable_group11_data_requests == True
+
+    # Remove 1 entity from HA
+    await entities[0].async_will_remove_from_hass()
+    assert coordinator._group11_entities == 0
+    assert device.enable_group11_data_requests == False
 
     await coordinator.async_shutdown()

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -10,18 +10,14 @@ from homeassistant.core import HomeAssistant
 from msmart.device import AirConditioner as AC
 from msmart.lan import _LanProtocol
 
-from custom_components.midea_ac.binary_sensor import (
-    MideaGroup2BinarySensor,
-    MideaGroup5BinarySensor,
-)
+from custom_components.midea_ac.binary_sensor import (MideaGroup2BinarySensor,
+                                                      MideaGroup5BinarySensor)
 from custom_components.midea_ac.coordinator import MideaDeviceUpdateCoordinator
-from custom_components.midea_ac.sensor import (
-    MideaGroup1Sensor,
-    MideaGroup2Sensor,
-    MideaGroup5Sensor,
-    MideaGroup7Sensor,
-    MideaGroup11Sensor,
-)
+from custom_components.midea_ac.sensor import (MideaGroup1Sensor,
+                                               MideaGroup2Sensor,
+                                               MideaGroup5Sensor,
+                                               MideaGroup7Sensor,
+                                               MideaGroup11Sensor)
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Split from #466. This PR adds sensors and binary sensors for the newly available data groups in `msmart-ng`.

### New Sensors (disabled by default)
- **Group 1:** Target compressor frequency, compressor frequency, current, voltage, indoor/outdoor coil temperature, discharge pipe temperature
- **Group 2:** Target indoor fan speed (rpm), indoor fan speed (rpm), water pump running (binary sensor)
- **Group 7:** Outdoor unit power (W)
- **Group 11:** Horizontal/vertical louvers angle (°)

### Implementation
- Entities are dynamically registered with the coordinator using a reference-counting pattern (matching the existing Group 5 approach).
- All new entities start disabled by default to avoid cluttering devices that don't support them.
- Uses HA constants (`REVOLUTIONS_PER_MINUTE`, `DEGREE`) for units.
- Includes unit tests for all new group registration/unregistration logic.
