### PR TITLE
Fix async_unload_entry to report actual unload result

### DIFF
--- a/custom_components/midea_ac/__init__.py
+++ b/custom_components/midea_ac/__init__.py
@@ -227,17 +227,14 @@ async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) ->
 
 async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Unload a config entry."""
-    # Remove the coordinator from global data
-    try:
-        hass.data[DOMAIN].pop(config_entry.entry_id)
-    except KeyError:
-        _LOGGER.warning("Failed remove device from global data.")
-
     # Forward unload to all platforms
-    for platform in _PLATFORMS:
-        await hass.config_entries.async_forward_entry_unload(config_entry, platform)
+    unload_ok = await hass.config_entries.async_unload_platforms(config_entry, _PLATFORMS)
 
-    return True
+    if unload_ok:
+        # Remove the coordinator from global data
+        hass.data[DOMAIN].pop(config_entry.entry_id)
+
+    return unload_ok
 
 
 async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -5,6 +5,7 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from homeassistant.config_entries import ConfigEntryState
 from homeassistant.core import HomeAssistant
 from msmart.const import DeviceType
 from pytest_homeassistant_custom_component.common import MockConfigEntry
@@ -326,3 +327,60 @@ async def test_config_entry_migration_from_6(hass: HomeAssistant) -> None:
     options = mock_config_entry.options
     assert CONF_UPDATE_INTERVAL in options
     assert options[CONF_UPDATE_INTERVAL] == UPDATE_INTERVAL
+
+
+async def test_unload_entry_success(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a successful unload removes the coordinator from global data."""
+
+    # Patch refresh and get_capabilities calls to allow integration to setup
+    with (patch("custom_components.midea_ac.config_flow.AC.get_capabilities"),
+          patch("custom_components.midea_ac.config_flow.AC.refresh")):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+    assert mock_config_entry.entry_id in hass.data[DOMAIN]
+
+    unload_ok = await hass.config_entries.async_unload(mock_config_entry.entry_id)
+    await hass.async_block_till_done()
+
+    assert unload_ok is True
+    assert mock_config_entry.state is ConfigEntryState.NOT_LOADED
+    assert mock_config_entry.entry_id not in hass.data[DOMAIN]
+
+
+async def test_unload_entry_platform_failure(
+    hass: HomeAssistant,
+    mock_config_entry: MockConfigEntry,
+) -> None:
+    """Test a failed platform unload leaves the coordinator in global data."""
+
+    # Patch refresh and get_capabilities calls to allow integration to setup
+    with (patch("custom_components.midea_ac.config_flow.AC.get_capabilities"),
+          patch("custom_components.midea_ac.config_flow.AC.refresh")):
+        mock_config_entry.add_to_hass(hass)
+        await hass.config_entries.async_setup(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert mock_config_entry.state is ConfigEntryState.LOADED
+
+    # Simulate a platform refusing to unload
+    with patch(
+        "homeassistant.config_entries.ConfigEntries.async_unload_platforms",
+        return_value=False,
+    ):
+        unload_ok = await hass.config_entries.async_unload(mock_config_entry.entry_id)
+        await hass.async_block_till_done()
+
+    assert unload_ok is False
+    assert mock_config_entry.entry_id in hass.data[DOMAIN]
+
+    # A failed unload leaves the entry in a non-recoverable state, so it
+    # can't be unloaded again. Shut down the coordinator directly so its
+    # refresh timer doesn't linger past the end of the test.
+    coordinator = hass.data[DOMAIN][mock_config_entry.entry_id]
+    await coordinator.async_shutdown()


### PR DESCRIPTION
async_unload_entry always returned True and removed the coordinator from hass.data before confirming the platforms actually unloaded. If a platform refused to unload, Home Assistant would still treat the entry as cleanly unloaded while its runtime state was gone.

Switch to async_unload_platforms and only remove the coordinator once the unload actually succeeds.