### PR TITLE
Fix coordinator entity availability to reflect failed refreshes

### DIFF
--- a/custom_components/midea_ac/coordinator.py
+++ b/custom_components/midea_ac/coordinator.py
@@ -180,7 +180,7 @@ class MideaCoordinatorEntity(CoordinatorEntity[MideaDeviceUpdateCoordinator], Ge
     @property
     def available(self) -> bool:
         """Check device availability."""
-        return self._device.online
+        return super().available and self._device.online
 
 
 class MideaGroup5Entity(MideaCoordinatorEntity):

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -12,7 +12,8 @@ from msmart.lan import _LanProtocol
 
 from custom_components.midea_ac.binary_sensor import (MideaGroup2BinarySensor,
                                                       MideaGroup5BinarySensor)
-from custom_components.midea_ac.coordinator import MideaDeviceUpdateCoordinator
+from custom_components.midea_ac.coordinator import (
+    MideaCoordinatorEntity, MideaDeviceUpdateCoordinator)
 from custom_components.midea_ac.sensor import (MideaGroup1Sensor,
                                                MideaGroup2Sensor,
                                                MideaGroup5Sensor,
@@ -239,6 +240,34 @@ async def test_group5_entity_request_enable(
     await entities[1].async_will_remove_from_hass()
     assert coordinator._group5_entities == 0
     assert device.enable_group5_data_requests == False
+
+    await coordinator.async_shutdown()
+
+
+async def test_entity_availability(
+    hass: HomeAssistant
+) -> None:
+    """Test entity availability depends on both the device and the coordinator refresh."""
+
+    # Create a mock device so online can be controlled directly
+    mock_device = MagicMock()
+    mock_device.online = True
+
+    coordinator = MideaDeviceUpdateCoordinator(hass, mock_device)
+    entity = MideaCoordinatorEntity(coordinator)
+
+    # Online device with a successful refresh is available
+    coordinator.last_update_success = True
+    assert entity.available == True
+
+    # Online device with a failed refresh is not available
+    coordinator.last_update_success = False
+    assert entity.available == False
+
+    # Offline device is not available, even after a successful refresh
+    mock_device.online = False
+    coordinator.last_update_success = True
+    assert entity.available == False
 
     await coordinator.async_shutdown()
 

--- a/tests/test_fan.py
+++ b/tests/test_fan.py
@@ -44,6 +44,7 @@ async def test_fresh_air_fan(
     coordinator = MagicMock(spec=MideaDeviceUpdateCoordinator)
     coordinator.device = mock_device
     coordinator.apply = AsyncMock()
+    coordinator.last_update_success = True
 
     # Store coordinator in global data
     hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = coordinator

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -90,6 +90,7 @@ async def test_cc_purifier_switch(
     coordinator = MagicMock(spec=MideaDeviceUpdateCoordinator)
     coordinator.device = mock_device
     coordinator.apply = AsyncMock()
+    coordinator.last_update_success = True
 
     # Store coordinator in global data
     hass.data.setdefault(DOMAIN, {})[mock_config_entry.entry_id] = coordinator


### PR DESCRIPTION
MideaCoordinatorEntity.available only checked device.online. A failed refresh could leave online=True stuck from the last successful update, so a broken coordinator still looked available.

Now also checks CoordinatorEntity.available (last_update_success), the default DataUpdateCoordinator contract.

Also sets last_update_success on the two tests that mock the coordinator with spec=MideaDeviceUpdateCoordinator, since MagicMock's spec doesn't expose that attribute.